### PR TITLE
Add LiteLLM Integration for Expanded Model Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.aider*
+lib/
+.env

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,27 @@
 UNOPKG := $(shell which unopkg 2>/dev/null || echo "/usr/lib/libreoffice/program/unopkg")
 LIBREOFFICE := $(shell which libreoffice 2>/dev/null || echo "/usr/lib/libreoffice/program/soffice")
 
-.PHONY: install-deps dev-install dev-refresh dev-run package clean
+.PHONY: help install-deps dev-install dev-refresh dev-run package clean
+
+help:
+	@echo "LocalWriter Development Makefile"
+	@echo ""
+	@echo "Available targets:"
+	@echo "  help           - Show this help message"
+	@echo "  install-deps   - Install Python dependencies in lib/"
+	@echo "  dev-install    - First-time dev setup (installs deps and registers extension)"
+	@echo "  dev-refresh    - Refresh extension after making changes"
+	@echo "  dev-run        - Start LibreOffice Writer"
+	@echo "  package        - Create localwriter.oxt package"
+	@echo "  clean          - Remove built files"
+	@echo ""
+	@echo "Typical workflow:"
+	@echo "  make dev-install   # First time setup"
+	@echo "  make dev-refresh   # After making changes"
+	@echo "  make dev-run       # To start LibreOffice"
+
+# Set help as default target
+.DEFAULT_GOAL := help
 
 install-deps:
 	@echo "Installing Python dependencies..."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+# Makefile for localwriter development
+
+UNOPKG := $(shell which unopkg 2>/dev/null || echo "/usr/lib/libreoffice/program/unopkg")
+LIBREOFFICE := $(shell which libreoffice 2>/dev/null || echo "/usr/lib/libreoffice/program/soffice")
+
+.PHONY: install-deps dev-install dev-refresh dev-run package clean
+
+install-deps:
+	@echo "Installing Python dependencies..."
+	mkdir -p lib
+	pip install litellm -t lib
+
+dev-install: install-deps
+	@echo "Installing development version..."
+	$(UNOPKG) remove org.extension.sample || true
+	yes yes | $(UNOPKG) add . > /dev/null
+
+dev-refresh:
+	@echo "Refreshing development installation..."
+	$(UNOPKG) remove org.extension.sample
+	yes yes | $(UNOPKG) add . > /dev/null
+
+dev-run:
+	@echo "Starting LibreOffice Writer..."
+	$(LIBREOFFICE) --writer &
+
+package:
+	@echo "Creating localwriter.oxt package..."
+	zip -r localwriter.oxt \
+		Accelerators.xcu \
+		Addons.xcu \
+		assets \
+		description.xml \
+		main.py \
+		META-INF \
+		registration \
+		README.md \
+		lib
+
+clean:
+	@echo "Cleaning up..."
+	rm -f localwriter.oxt

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ dev-run:
 	@echo "Starting LibreOffice Writer..."
 	$(LIBREOFFICE) --writer &
 
-package:
+package: install-deps
 	@echo "Creating localwriter.oxt package..."
 	zip -r localwriter.oxt \
 		Accelerators.xcu \
@@ -57,6 +57,10 @@ package:
 		README.md \
 		lib
 
-clean:
+clean: clean-deps
 	@echo "Cleaning up..."
 	rm -f localwriter.oxt
+
+clean-deps:
+	@echo "Removing installed dependencies..."
+	find lib -mindepth 1 -not -name 'README.txt' -delete

--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ In the settings, you can configure:
 *   Maximum number of additional tokens (above the number of letters in the original selection) for "Edit Selection."
 *   Custom "system prompts" for both "Extend Selection" and "Edit Selection." These prompts are prepended to the selection before sending it to the language model.  For example, you can use a sample of your writing to guide the model's style.
 
-## Local Development
+## Contributing
+
+Help with development is always welcome. localwriter has a number of outstanding feature requests by users. Feel free to work on any of them, and you can help improve freedom-respecting local AI.
+
+### Local Development Setup
 
 For developers who want to modify or contribute to Localwriter, you can run and test the extension directly from your source code without packaging it into an `.oxt` file. This allows for quick iteration and seeing changes reflected in the LibreOffice UI.
-
-### Running in Developer Mode
-
-To run the extension from your local Git repository and test changes efficiently:
 
 1. **Clone the Repository (if not already done):**
    - Clone the Localwriter repository to your local machine if you haven't already:
@@ -130,13 +130,9 @@ To run the extension from your local Git repository and test changes efficiently
      ```
    - Replace `org.extension.sample` with the identifier from `description.xml` if different.
 
-This approach ensures you can see the full extension behavior (including menu integration and UI dialogs) while making changes directly in your Git repository, avoiding the need to repeatedly package or copy files.
+### Building the Extension Package
 
-## Contributing
-
-Help with development is always welcome. localwriter has a number of outstanding feature requests by users. Feel free to work on any of them, and you can help improve freedom-respecting local AI. 
-
-### Building localwriter
+To create a distributable `.oxt` package:
 
 In a terminal, change directory into the localwriter repository top-level directory, then run the following command:
 
@@ -152,7 +148,7 @@ zip -r localwriter.oxt \
   README.md
 ````
 
-This will create the file `localwriter.oxt` which you can open with libreoffice to install the localwriter extension. You can also change the file extension to .zip and manually unzip the extension file, if you want to inspect a localwriter `.oxt` file yourself. It is all human-readable, since python is an interpreted language. 
+This will create the file `localwriter.oxt` which you can open with libreoffice to install the localwriter extension. You can also change the file extension to .zip and manually unzip the extension file, if you want to inspect a localwriter `.oxt` file yourself. It is all human-readable, since python is an interpreted language.
 
 
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,14 @@ To run the extension from your local Git repository and test changes efficiently
      ```
      /usr/lib/libreoffice/program/unopkg remove org.extension.sample; yes yes | /usr/lib/libreoffice/program/unopkg add . > /dev/null
      ```
-   - Alternatively, use the provided Makefile (see below) which automates this process.
+   - Alternatively, use the provided Makefile which provides these commands:
+     ```bash
+     make dev-install   # First time setup
+     make dev-refresh   # After making changes
+     make dev-run       # To start LibreOffice
+     make package       # Create distribution .oxt file
+     ```
+     Run `make help` to see all available commands.
 
 4. **Restart LibreOffice:**
    - Close and reopen LibreOffice Writer or Calc. You should see the "localwriter" menu with options like "Extend Selection", "Edit Selection", and "Settings" in the menu bar.

--- a/README.md
+++ b/README.md
@@ -109,14 +109,15 @@ To run the extension from your local Git repository and test changes efficiently
 
 3. **Register the Extension Temporarily:**
    - Use the `unopkg` tool to register the extension directly from your repository folder. This avoids the need to package the extension as an `.oxt` file during development.
-   - Run the following command, replacing `/path/to/localwriter/` with the path to your cloned repository:
+   - For development, you'll need to remove and re-add the extension each time you make changes:
      ```
-     unopkg add /path/to/localwriter/
+     unopkg remove org.extension.sample; yes yes | unopkg add . > /dev/null
      ```
    - On Linux, `unopkg` is often located at `/usr/lib/libreoffice/program/unopkg`. Adjust the command if needed:
      ```
-     /usr/lib/libreoffice/program/unopkg add /path/to/localwriter/
+     /usr/lib/libreoffice/program/unopkg remove org.extension.sample; yes yes | /usr/lib/libreoffice/program/unopkg add . > /dev/null
      ```
+   - Alternatively, use the provided Makefile (see below) which automates this process.
 
 4. **Restart LibreOffice:**
    - Close and reopen LibreOffice Writer or Calc. You should see the "localwriter" menu with options like "Extend Selection", "Edit Selection", and "Settings" in the menu bar.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Consider donating to support development: https://ko-fi.com/johnbalis
 
 ## About
 
-This is a LibreOffice Writer extension that enables inline generative editing with local inference. It's compatible with language models supported by `text-generation-webui` and `ollama`.
+This is a LibreOffice Writer extension that enables inline generative editing with local inference. It's compatible with language models supported by `text-generation-webui` and `ollama`. Starting from version 0.0.8, it uses `LiteLLM` for model interaction, providing a unified interface to various model backends.
 
 ## Table of Contents
 
@@ -81,6 +81,8 @@ In the settings, you can configure:
 *   Maximum number of additional tokens for "Extend Selection."
 *   Maximum number of additional tokens (above the number of letters in the original selection) for "Edit Selection."
 *   Custom "system prompts" for both "Extend Selection" and "Edit Selection." These prompts are prepended to the selection before sending it to the language model.  For example, you can use a sample of your writing to guide the model's style.
+*   Endpoint URL/Port for connecting to the backend model runner.
+*   Model name (required for Ollama and some other backends).
 
 ## Local Development
 
@@ -97,7 +99,15 @@ To run the extension from your local Git repository and test changes efficiently
      cd localwriter
      ```
 
-2. **Register the Extension Temporarily:**
+2. **Vendoring LiteLLM for Development (Optional):**
+   - If you are working on a version that uses LiteLLM, you need to vendor the library and its dependencies into the `lib/` directory:
+     ```
+     mkdir -p lib
+     pip install litellm -t lib
+     ```
+   - Ensure all dependencies are included in `lib/` to avoid import issues in LibreOffice's Python environment.
+
+3. **Register the Extension Temporarily:**
    - Use the `unopkg` tool to register the extension directly from your repository folder. This avoids the need to package the extension as an `.oxt` file during development.
    - Run the following command, replacing `/path/to/localwriter/` with the path to your cloned repository:
      ```
@@ -108,22 +118,22 @@ To run the extension from your local Git repository and test changes efficiently
      /usr/lib/libreoffice/program/unopkg add /path/to/localwriter/
      ```
 
-3. **Restart LibreOffice:**
+4. **Restart LibreOffice:**
    - Close and reopen LibreOffice Writer or Calc. You should see the "localwriter" menu with options like "Extend Selection", "Edit Selection", and "Settings" in the menu bar.
 
-4. **Make and Test Changes:**
+5. **Make and Test Changes:**
    - Edit the source files (e.g., `main.py`) directly in your repository folder using your preferred editor.
    - After making changes, restart LibreOffice to reload the updated code. Test the functionality and UI elements (dialogs, menu actions) directly in LibreOffice.
    - Note: Restarting is often necessary for Python script changes to take effect, as LibreOffice caches modules.
 
-5. **Commit Changes to Git:**
+6. **Commit Changes to Git:**
    - Since you're working directly in your Git repository, commit your changes as needed:
      ```
      git add main.py
      git commit -m "Updated extension logic for ExtendSelection"
      ```
 
-6. **Unregister the Extension (Optional):**
+7. **Unregister the Extension (Optional):**
    - If you need to remove the temporary registration, use:
      ```
      unopkg remove org.extension.sample
@@ -149,12 +159,19 @@ zip -r localwriter.oxt \
   main.py \
   META-INF \
   registration \
-  README.md
+  README.md \
+  lib
 ````
 
 This will create the file `localwriter.oxt` which you can open with libreoffice to install the localwriter extension. You can also change the file extension to .zip and manually unzip the extension file, if you want to inspect a localwriter `.oxt` file yourself. It is all human-readable, since python is an interpreted language. 
 
-
+**Note on Vendoring LiteLLM for Distribution:**
+- Before building the `.oxt` file for distribution, ensure the `lib/` directory contains the vendored `LiteLLM` library and its dependencies. You can do this by running:
+  ```
+  mkdir -p lib
+  pip install litellm -t lib
+  ```
+- This ensures that the extension is self-contained and works in environments without external Python package access.
 
 ## License 
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ This is a LibreOffice Writer extension that enables inline generative editing wi
         *   [text-generation-webui](#text-generation-webui)
         *   [Ollama](#ollama)
 *   [Settings](#settings)
-*   [Local Development](#local-development)
-    *   [Running in Developer Mode](#running-in-developer-mode)
+*   [Contributing](#contributing)
+    *   [Local Development Setup](#local-development-setup)
+    *   [Building the Extension Package](#building-the-extension-package)
 *   [License](#license)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ This is a LibreOffice Writer extension that enables inline generative editing wi
         *   [text-generation-webui](#text-generation-webui)
         *   [Ollama](#ollama)
 *   [Settings](#settings)
-*   [Local Development](#local-development)
-    *   [Running in Developer Mode](#running-in-developer-mode)
+*   [Contributing](#contributing)
+    *   [Local Development Setup](#local-development-setup)
+    *   [Building the Extension Package](#building-the-extension-package)
 *   [License](#license)
 
 ## Features
@@ -84,13 +85,13 @@ In the settings, you can configure:
 *   Endpoint URL/Port for connecting to the backend model runner.
 *   Model name (required for Ollama and some other backends).
 
-## Local Development
+## Contributing
+
+Help with development is always welcome. localwriter has a number of outstanding feature requests by users. Feel free to work on any of them, and you can help improve freedom-respecting local AI.
+
+### Local Development Setup
 
 For developers who want to modify or contribute to Localwriter, you can run and test the extension directly from your source code without packaging it into an `.oxt` file. This allows for quick iteration and seeing changes reflected in the LibreOffice UI.
-
-### Running in Developer Mode
-
-To run the extension from your local Git repository and test changes efficiently:
 
 1. **Clone the Repository (if not already done):**
    - Clone the Localwriter repository to your local machine if you haven't already:
@@ -99,10 +100,9 @@ To run the extension from your local Git repository and test changes efficiently
      cd localwriter
      ```
 
-2. **Vendoring LiteLLM for Development (Optional):**
-   - If you are working on a version that uses LiteLLM, you need to vendor the library and its dependencies into the `lib/` directory:
+2. **Vendoring LiteLLM for Development:**
+   - You need to vendor the library and its dependencies into the `lib/` directory:
      ```
-     mkdir -p lib
      pip install litellm -t lib
      ```
    - Ensure all dependencies are included in `lib/` to avoid import issues in LibreOffice's Python environment.
@@ -150,11 +150,10 @@ To run the extension from your local Git repository and test changes efficiently
 
 This approach ensures you can see the full extension behavior (including menu integration and UI dialogs) while making changes directly in your Git repository, avoiding the need to repeatedly package or copy files.
 
-## Contributing
 
-Help with development is always welcome. localwriter has a number of outstanding feature requests by users. Feel free to work on any of them, and you can help improve freedom-respecting local AI. 
+### Building the Extension Package
 
-### Building localwriter
+To create a distributable `.oxt` package:
 
 In a terminal, change directory into the localwriter repository top-level directory, then run the following command:
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This is a LibreOffice Writer extension that enables inline generative editing wi
         *   [text-generation-webui](#text-generation-webui)
         *   [Ollama](#ollama)
 *   [Settings](#settings)
+*   [Local Development](#local-development)
+    *   [Running in Developer Mode](#running-in-developer-mode)
 *   [License](#license)
 
 ## Features
@@ -79,6 +81,56 @@ In the settings, you can configure:
 *   Maximum number of additional tokens for "Extend Selection."
 *   Maximum number of additional tokens (above the number of letters in the original selection) for "Edit Selection."
 *   Custom "system prompts" for both "Extend Selection" and "Edit Selection." These prompts are prepended to the selection before sending it to the language model.  For example, you can use a sample of your writing to guide the model's style.
+
+## Local Development
+
+For developers who want to modify or contribute to Localwriter, you can run and test the extension directly from your source code without packaging it into an `.oxt` file. This allows for quick iteration and seeing changes reflected in the LibreOffice UI.
+
+### Running in Developer Mode
+
+To run the extension from your local Git repository and test changes efficiently:
+
+1. **Clone the Repository (if not already done):**
+   - Clone the Localwriter repository to your local machine if you haven't already:
+     ```
+     git clone https://github.com/balis-john/localwriter.git
+     cd localwriter
+     ```
+
+2. **Register the Extension Temporarily:**
+   - Use the `unopkg` tool to register the extension directly from your repository folder. This avoids the need to package the extension as an `.oxt` file during development.
+   - Run the following command, replacing `/path/to/localwriter/` with the path to your cloned repository:
+     ```
+     unopkg add /path/to/localwriter/
+     ```
+   - On Linux, `unopkg` is often located at `/usr/lib/libreoffice/program/unopkg`. Adjust the command if needed:
+     ```
+     /usr/lib/libreoffice/program/unopkg add /path/to/localwriter/
+     ```
+
+3. **Restart LibreOffice:**
+   - Close and reopen LibreOffice Writer or Calc. You should see the "localwriter" menu with options like "Extend Selection", "Edit Selection", and "Settings" in the menu bar.
+
+4. **Make and Test Changes:**
+   - Edit the source files (e.g., `main.py`) directly in your repository folder using your preferred editor.
+   - After making changes, restart LibreOffice to reload the updated code. Test the functionality and UI elements (dialogs, menu actions) directly in LibreOffice.
+   - Note: Restarting is often necessary for Python script changes to take effect, as LibreOffice caches modules.
+
+5. **Commit Changes to Git:**
+   - Since you're working directly in your Git repository, commit your changes as needed:
+     ```
+     git add main.py
+     git commit -m "Updated extension logic for ExtendSelection"
+     ```
+
+6. **Unregister the Extension (Optional):**
+   - If you need to remove the temporary registration, use:
+     ```
+     unopkg remove org.extension.sample
+     ```
+   - Replace `org.extension.sample` with the identifier from `description.xml` if different.
+
+This approach ensures you can see the full extension behavior (including menu integration and UI dialogs) while making changes directly in your Git repository, avoiding the need to repeatedly package or copy files.
 
 ## Contributing
 

--- a/description.xml
+++ b/description.xml
@@ -4,7 +4,7 @@
   xmlns:dep="http://openoffice.org/extensions/description/2006"
   xmlns:xlink="http://www.w3.org/1999/xlink">
     <identifier value="org.extension.sample"/>
-    <version value="0.0.7"/>
+    <version value="0.0.8"/>
     <registration>
         <simple-license accept-by="admin" default-license-id="ID0" suppress-on-update="true" >
             <license-text xlink:href="registration/license.txt" lang="en" license-id="ID0" />

--- a/lib/README.txt
+++ b/lib/README.txt
@@ -1,0 +1,11 @@
+This directory is intended to hold the vendored LiteLLM library and its dependencies for the localwriter extension.
+
+To populate this directory, run the following commands in the root of the repository:
+  mkdir -p lib
+  pip install litellm -t lib
+
+This ensures that all necessary dependencies are included for use within LibreOffice's Python environment, which may not have access to external packages.
+
+Note for Developers:
+- Ensure that the 'lib' directory is included when building the .oxt file for distribution.
+- If you are testing locally, you may need to restart LibreOffice after adding or updating the contents of this directory to ensure the changes are recognized.

--- a/main.py
+++ b/main.py
@@ -462,9 +462,15 @@ class MainJob(unohelper.Base, XJobExecutor):
                 print("AdvancedToggleListener initialized")
             
             def itemStateChanged(self, event):
-                print(f"\nAdvanced toggle state changed. Source: {event.Source}")
-                print(f"Event State: {event.State}")
-                print(f"Event Source Model State: {event.Source.Model.State}")
+                try:
+                    print(f"\nAdvanced toggle state changed. Source: {event.Source}")
+                    print(f"Event State: {event.State}")
+                    if hasattr(event.Source, 'Model') and hasattr(event.Source.Model, 'State'):
+                        print(f"Event Source Model State: {event.Source.Model.State}")
+                    else:
+                        print("Could not access Source.Model.State")
+                except Exception as e:
+                    print(f"Error in itemStateChanged: {str(e)}")
                 
                 is_advanced = event.State == 1
                 current_selection = self.combo_provider.Model.Text
@@ -510,7 +516,11 @@ class MainJob(unohelper.Base, XJobExecutor):
         check_advanced = dialog.getControl("check_advanced")
         self._advanced_listener = AdvancedToggleListener(combo_provider)  # Keep reference to prevent GC
         check_advanced.addItemListener(self._advanced_listener)
-        print(f"Listener registered. Active listeners: {check_advanced.getItemListeners()}")
+        try:
+            listeners = check_advanced.getItemListeners()
+            print(f"Listener registered. Found {len(listeners)} active listeners")
+        except Exception as e:
+            print(f"Could not check listeners (non-fatal): {str(e)}")
         
         # Debug checkbox state
         print(f"Checkbox initial state: {check_advanced.Model.State}")

--- a/main.py
+++ b/main.py
@@ -334,7 +334,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                     
                     # Default to requiring both fields unless we can confirm otherwise
                     needs_key = True
-                    needs_endpoint = False
+                    needs_endpoint = True
                     api_base = None
 
                     try:
@@ -348,22 +348,21 @@ class MainJob(unohelper.Base, XJobExecutor):
                                 needs_key = provider_config.get_api_key('needed') == 'needed'
                             except Exception as e:
                                 print(f"Error checking API key requirement: {str(e)}")
-                                needs_key = True  # Default to requiring key if check fails
+                                # Keep default of requiring key
                         
                         if hasattr(provider_config, 'get_api_base'):
                             try:
                                 api_base = provider_config.get_api_base()
                                 if api_base:
-                                    needs_endpoint = 'localhost' in api_base or '127.0.0.1' in api_base
+                                    # Only disable endpoint if we confirm it's not needed
+                                    needs_endpoint = True
                             except Exception as e:
                                 print(f"Error checking endpoint requirement: {str(e)}")
-                                needs_endpoint = False  # Default to not requiring endpoint if check fails
+                                # Keep default of requiring endpoint
                         
                     except Exception as e:
                         print(f"Error getting provider config: {str(e)}")
-                        # If we can't get config, assume key is needed but endpoint isn't
-                        needs_key = True
-                        needs_endpoint = False
+                        # If we can't get config, keep both fields enabled by default
 
                     def update_widget_state(widget, is_required, help_text, example_text=None):
                         """Helper to update widget state consistently"""

--- a/main.py
+++ b/main.py
@@ -353,9 +353,10 @@ class MainJob(unohelper.Base, XJobExecutor):
                         if hasattr(provider_config, 'get_api_base'):
                             try:
                                 api_base = provider_config.get_api_base()
+                                print(f"Provider API base: {api_base}")
                                 if api_base:
-                                    # Only disable endpoint if we confirm it's not needed
-                                    needs_endpoint = True
+                                    needs_endpoint = 'localhost' in api_base or '127.0.0.1' in api_base
+                                    print(f"Endpoint required: {needs_endpoint}")
                             except Exception as e:
                                 print(f"Error checking endpoint requirement: {str(e)}")
                                 # Keep default of requiring endpoint

--- a/main.py
+++ b/main.py
@@ -534,13 +534,21 @@ class MainJob(unohelper.Base, XJobExecutor):
 
         if dialog.execute():
             result = {
-                "endpoint": edit_endpoint.getModel().Text,
                 "model": combo_model.Model.Text,
                 "provider": combo_provider.Model.Text,
-                "api_key": edit_api_key.getModel().Text,
                 "extend_selection_system_prompt": edit_extend_selection_system_prompt.getModel().Text,
                 "edit_selection_system_prompt": edit_edit_selection_system_prompt.getModel().Text
             }
+            
+            # Only include endpoint if control is enabled
+            if edit_endpoint.isEnabled():
+                result["endpoint"] = edit_endpoint.getModel().Text
+            
+            # Only include API key if control is enabled
+            if edit_api_key.isEnabled():
+                result["api_key"] = edit_api_key.getModel().Text
+            
+            # Handle numeric fields
             if edit_extend_selection_max_tokens.getModel().Text.isdigit():
                 result["extend_selection_max_tokens"] = int(edit_extend_selection_max_tokens.getModel().Text)
             if edit_edit_selection_max_new_tokens.getModel().Text.isdigit():
@@ -747,8 +755,8 @@ class MainJob(unohelper.Base, XJobExecutor):
                                 if "edit_selection_system_prompt" in result:
                                     self.set_config("edit_selection_system_prompt", result["edit_selection_system_prompt"])
 
+                                # Only save endpoint if it exists and starts with http
                                 if "endpoint" in result and result["endpoint"].startswith("http"):
-                                    # Ensure endpoint ends with a single slash to match LiteLLM's behavior
                                     endpoint = result["endpoint"].rstrip('/')
                                     self.set_config("endpoint", endpoint)
 

--- a/main.py
+++ b/main.py
@@ -529,7 +529,7 @@ class MainJob(unohelper.Base, XJobExecutor):
         btn_test = dialog.getControl("btn_test")
         test_listener = TestConnectionListener(
             edit_endpoint,
-            edit_model, 
+            combo_model, 
             combo_provider,
             edit_api_key,
             dialog.getControl("test_result"),

--- a/main.py
+++ b/main.py
@@ -321,14 +321,14 @@ class MainJob(unohelper.Base, XJobExecutor):
         if current_provider in providers:
             combo_provider.Model.Text = current_provider
         
+        edit_api_key = dialog.getControl("edit_api_key")
+        edit_api_key.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("api_key", "")))))
+        
         edit_model = dialog.getControl("edit_model")
         edit_model.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("model", "")))))
         
         edit_endpoint = dialog.getControl("edit_endpoint")
         edit_endpoint.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("endpoint", "http://127.0.0.1:5000")))))
-        
-        edit_api_key = dialog.getControl("edit_api_key")
-        edit_api_key.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("api_key", "")))))
         
         edit_extend_selection_max_tokens = dialog.getControl("edit_extend_selection_max_tokens")
         edit_extend_selection_max_tokens.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("extend_selection_max_tokens", "70")))))

--- a/main.py
+++ b/main.py
@@ -222,7 +222,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                 setattr(model, key, value)
         label_width = WIDTH - BUTTON_WIDTH - HORI_SEP - HORI_MARGIN * 2
         add("label_endpoint", "FixedText", HORI_MARGIN, VERT_MARGIN, label_width, LABEL_HEIGHT, 
-            {"Label": "Endpoint URL/Port (Local or Proxy):", "NoLabel": True})
+            {"Label": "Endpoint URL/Port (Local or Proxy, e.g., https://api.x.ai/v1/chat/completions for Grok):", "NoLabel": True})
         add("btn_ok", "Button", HORI_MARGIN + label_width + HORI_SEP, VERT_MARGIN, 
                 BUTTON_WIDTH, BUTTON_HEIGHT, {"PushButtonType": OK, "DefaultButton": True})
         add("edit_endpoint", "Edit", HORI_MARGIN, LABEL_HEIGHT,

--- a/main.py
+++ b/main.py
@@ -407,8 +407,14 @@ class MainJob(unohelper.Base, XJobExecutor):
                         try:
                             models = provider_config.get_models(**get_model_args)
                             if models:
+                                # Strip provider prefix if it matches current provider
+                                prefix = f"{provider}/"
+                                stripped_models = [
+                                    model[len(prefix):] if model.startswith(prefix) else model
+                                    for model in models
+                                ]
                                 self.model_ctrl.removeItems(0, self.model_ctrl.getItemCount())
-                                self.model_ctrl.addItems(sorted(models), 0)
+                                self.model_ctrl.addItems(sorted(stripped_models), 0)
                                 self.model_ctrl.Model.HelpText = f"Available models for {provider}"
                             else:
                                 self.model_ctrl.Model.HelpText = "No models found - check API key/endpoint"

--- a/main.py
+++ b/main.py
@@ -199,7 +199,7 @@ class MainJob(unohelper.Base, XJobExecutor):
         VERT_SEP = 4
         LABEL_HEIGHT = BUTTON_HEIGHT + 5
         EDIT_HEIGHT = 24
-        HEIGHT = VERT_MARGIN * 7 + LABEL_HEIGHT * 8 + VERT_SEP * 9 + EDIT_HEIGHT * 8
+        HEIGHT = VERT_MARGIN * 7 + LABEL_HEIGHT * 8 + VERT_SEP * 9 + EDIT_HEIGHT * 8 + 350
         import uno
         from com.sun.star.awt.PosSize import POS, SIZE, POSSIZE
         from com.sun.star.awt.PushButtonType import OK, CANCEL

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ import re
 # Import LiteLLM (to be vendored in lib/)
 try:
     sys.path.append(os.path.join(os.path.dirname(__file__), 'lib'))
-    from litellm import completion
+    from litellm import completion, check_valid_key
 except ImportError:
     # Fallback or error handling if LiteLLM is not available
     def completion(*args, **kwargs):
@@ -386,7 +386,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                     litellm._turn_off_debug()
 
         btn_test = dialog.getControl("btn_test")
-        test_listener = TestConnectionListener(edit_endpoint, edit_model, combo_provider, edit_api_key, dialog.getControl("test_result"), self)
+        test_listener = TestConnectionListener(edit_endpoint, edit_model, combo_provider, edit_api_key, dialog.getControl("test_result"), self, api_key_label)
         btn_test.addActionListener(test_listener)
 
         if dialog.execute():

--- a/main.py
+++ b/main.py
@@ -328,19 +328,15 @@ class MainJob(unohelper.Base, XJobExecutor):
                 self.api_key_ctrl.Model.BackgroundColor = 0xFFFFFF
                 
                 try:
-                    # Turn on debug logging
-                    litellm._turn_on_debug()
                     print(f"Checking if provider '{provider}' requires API key...")
                     
-                    # Test with empty key to see if provider requires one
-                    result = check_valid_key(
-                        model=f"{provider}/dummy-model",  # dummy model name  
-                        api_key=""
-                    )
-                    print(f"check_valid_key result for {provider}: {result}")
-                    
-                    if result:
-                        # If check passes with empty key, provider doesn't need one
+                    provider_config = litellm.utils.ProviderConfigManager.get_provider_model_info(
+                            model=None,
+                            provider=litellm.utils.LlmProviders(provider))
+
+                    needs_key = provider_config.get_api_key('needed') == 'needed'
+
+                    if not needs_key:
                         print(f"Provider '{provider}' does NOT require API key")
                         self.api_key_ctrl.setEditable(False)
                         self.api_key_ctrl.setEnable(False)
@@ -348,6 +344,13 @@ class MainJob(unohelper.Base, XJobExecutor):
                         self.api_key_ctrl.Model.BackgroundColor = 0xEEEEEE
                     else:
                         print(f"Provider '{provider}' requires API key")
+
+                    #AI! configure the endpoint GUI field in a similar manner to how we toggle the API key field (see above). The line below tells us if we need the endpoint
+                    #needs_endpoint = 'localhost' in provider_config.get_api_base() or '127.0.0.1' in provider_config.get_api_base()
+
+                    # Turn on debug logging - get_models() may do a request
+                    #litellm._turn_on_debug()
+                    #models_for_provider = provider_config.get_models()  # NOTE: this isn't valid until api_key or endpoint has been specified depending on the provider
                     
                 except Exception as e:
                     print(f"Error checking key requirement for {provider}: {str(e)}")

--- a/main.py
+++ b/main.py
@@ -327,19 +327,33 @@ class MainJob(unohelper.Base, XJobExecutor):
                 self.api_key_ctrl.Model.BackgroundColor = 0xFFFFFF
                 
                 try:
+                    # Turn on debug logging
+                    import litellm
+                    litellm.set_verbose = True
+                    print(f"Checking if provider '{provider}' requires API key...")
+                    
                     # Test with empty key to see if provider requires one
-                    if check_valid_key(
-                        model=f"{provider}/dummy-model",  # dummy model name
+                    result = check_valid_key(
+                        model=f"{provider}/dummy-model",  # dummy model name  
                         api_key=""
-                    ):
+                    )
+                    print(f"check_valid_key result for {provider}: {result}")
+                    
+                    if result:
                         # If check passes with empty key, provider doesn't need one
+                        print(f"Provider '{provider}' does NOT require API key")
                         self.api_key_ctrl.setEditable(False)
                         self.api_key_ctrl.setEnable(False)
                         self.api_key_ctrl.Model.HelpText = "This provider doesn't require an API key"
                         self.api_key_ctrl.Model.BackgroundColor = 0xEEEEEE
+                    else:
+                        print(f"Provider '{provider}' requires API key")
                     
                 except Exception as e:
-                    print(f"Error checking key requirement: {str(e)}")
+                    print(f"Error checking key requirement for {provider}: {str(e)}")
+                finally:
+                    # Turn off debug logging
+                    litellm.set_verbose = False
                     # Keep defaults (key required) if check fails
 
             def disposing(self, event):

--- a/main.py
+++ b/main.py
@@ -14,30 +14,12 @@ import re
 # Import LiteLLM (to be vendored in lib/)
 try:
     sys.path.append(os.path.join(os.path.dirname(__file__), 'lib'))
-    from litellm import completion, check_valid_key
     import litellm
 except ImportError:
-    # Fallback or error handling if LiteLLM is not available
-    def completion(*args, **kwargs):
-        raise Exception("LiteLLM library not found. Please ensure it is installed in the lib/ directory.")
+    raise Exception("LiteLLM library not found. Please ensure it is installed in the lib/ directory.")
 
-from com.sun.star.beans import PropertyValue
-from com.sun.star.container import XNamed
-
-
-def log_to_file(message):
-    # Get the user's home directory
-    home_directory = os.path.expanduser('~')
-    
-    # Define the log file path
-    log_file_path = os.path.join(home_directory, 'log.txt')
-    
-    # Set up logging configuration
-    logging.basicConfig(filename=log_file_path, level=logging.INFO, format='%(asctime)s - %(message)s')
-    
-    # Log the input message
-    logging.info(message)
-
+# Turn on litellm debug for now
+litellm._turn_on_debug()
 
 # The MainJob is a UNO component derived from unohelper.Base class
 # and also the XJobExecutor, the implemented interface
@@ -78,7 +60,7 @@ class MainJob(unohelper.Base, XJobExecutor):
             if api_key:
                 kwargs["api_key"] = api_key
 
-            return completion(**kwargs)
+            return litellm.completion(**kwargs)
         except Exception as e:
             raise Exception(f"Completion error: {str(e)}")
 
@@ -504,9 +486,6 @@ class MainJob(unohelper.Base, XJobExecutor):
                 # Only use API key if the control is enabled
                 api_key = self.api_key_ctrl.getModel().Text if self.api_key_ctrl.isEnabled() else None
                 try:
-                    # Turn on debug for this test call
-                    litellm._turn_on_debug()
-
                     response = self.main_job.call_completion(
                         messages=[{"role": "user", "content": "Hello, are you working?"}],
                         max_tokens=10,

--- a/main.py
+++ b/main.py
@@ -489,10 +489,14 @@ class MainJob(unohelper.Base, XJobExecutor):
                 pass
 
             def actionPerformed(self, event):
-                endpoint = self.endpoint_ctrl.getModel().Text
                 model_name = self.model_ctrl.getModel().Text
                 provider = self.provider_ctrl.getModel().Text
-                api_key = self.api_key_ctrl.getModel().Text
+                
+                # Only use endpoint if the control is enabled
+                endpoint = self.endpoint_ctrl.getModel().Text if self.endpoint_ctrl.isEnabled() else None
+                
+                # Only use API key if the control is enabled
+                api_key = self.api_key_ctrl.getModel().Text if self.api_key_ctrl.isEnabled() else None
                 try:
                     # Turn on debug for this test call
                     litellm._turn_on_debug()

--- a/main.py
+++ b/main.py
@@ -256,20 +256,20 @@ class MainJob(unohelper.Base, XJobExecutor):
         add("combo_provider", "ComboBox", HORI_MARGIN, LABEL_HEIGHT + VERT_MARGIN,
                 WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Dropdown": True})
         
-        add("label_model", "FixedText", HORI_MARGIN, LABEL_HEIGHT + VERT_MARGIN + VERT_SEP + EDIT_HEIGHT, label_width, LABEL_HEIGHT, 
+        add("label_api_key", "FixedText", HORI_MARGIN, LABEL_HEIGHT + VERT_MARGIN + VERT_SEP + EDIT_HEIGHT, label_width, LABEL_HEIGHT, 
+            {"Label": "API Key (Optional, use with caution):", "NoLabel": True})
+        add("edit_api_key", "Edit", HORI_MARGIN, LABEL_HEIGHT*2 + VERT_MARGIN + VERT_SEP + EDIT_HEIGHT, 
+                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("api_key", "")), "EchoChar": ord('*')})
+        
+        add("label_model", "FixedText", HORI_MARGIN, LABEL_HEIGHT*2 + VERT_MARGIN + VERT_SEP*2 + EDIT_HEIGHT*2, label_width, LABEL_HEIGHT, 
             {"Label": "Model (Required by Ollama):", "NoLabel": True})
-        add("edit_model", "Edit", HORI_MARGIN, LABEL_HEIGHT*2 + VERT_MARGIN + VERT_SEP + EDIT_HEIGHT, 
+        add("edit_model", "Edit", HORI_MARGIN, LABEL_HEIGHT*3 + VERT_MARGIN + VERT_SEP*2 + EDIT_HEIGHT*2, 
                 WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("model", ""))})
         
-        add("label_endpoint", "FixedText", HORI_MARGIN, LABEL_HEIGHT*2 + VERT_MARGIN + VERT_SEP*2 + EDIT_HEIGHT*2, label_width, LABEL_HEIGHT, 
+        add("label_endpoint", "FixedText", HORI_MARGIN, LABEL_HEIGHT*3 + VERT_MARGIN + VERT_SEP*3 + EDIT_HEIGHT*3, label_width, LABEL_HEIGHT, 
             {"Label": "Endpoint URL/Port (Local or Proxy, e.g., https://api.x.ai/v1/chat/completions for Grok):", "NoLabel": True})
-        add("edit_endpoint", "Edit", HORI_MARGIN, LABEL_HEIGHT*3 + VERT_MARGIN + VERT_SEP*2 + EDIT_HEIGHT*2, 
+        add("edit_endpoint", "Edit", HORI_MARGIN, LABEL_HEIGHT*4 + VERT_MARGIN + VERT_SEP*3 + EDIT_HEIGHT*3, 
                 WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("endpoint", "http://127.0.0.1:5000"))})
-        
-        add("label_api_key", "FixedText", HORI_MARGIN, LABEL_HEIGHT*5 + VERT_MARGIN + VERT_SEP*5 + EDIT_HEIGHT*3, label_width, LABEL_HEIGHT, 
-            {"Label": "API Key (Optional, use with caution):", "NoLabel": True})
-        add("edit_api_key", "Edit", HORI_MARGIN, LABEL_HEIGHT*6 + VERT_MARGIN + VERT_SEP*6 + EDIT_HEIGHT*3, 
-                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("api_key", "")), "EchoChar": ord('*')})
         
         add("label_extend_selection_max_tokens", "FixedText", HORI_MARGIN, LABEL_HEIGHT*7 + VERT_MARGIN + VERT_SEP*7 + EDIT_HEIGHT*4, label_width, LABEL_HEIGHT, 
             {"Label": "Extend Selection Max Tokens:", "NoLabel": True})

--- a/main.py
+++ b/main.py
@@ -351,6 +351,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                         if api_base:
                             needs_endpoint = 'localhost' in api_base or '127.0.0.1' in api_base
                         
+                        #AI the code between here
                         # Update endpoint field
                         if needs_endpoint:
                             self.endpoint_ctrl.Model.HelpText = f"Required endpoint (e.g. {api_base})"
@@ -358,6 +359,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                         else:
                             self.endpoint_ctrl.Model.HelpText = "Leave blank to use provider's default endpoint"
                             self.endpoint_ctrl.Model.BackgroundColor = 0xEEEEEE
+                        #AI and here should move outside this try block and go after the api_key_ctrl GUI updates for consistency
                     except:
                         needs_key = True  # Fallback to requiring key if check fails
 
@@ -374,6 +376,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                         self.api_key_ctrl.Model.HelpText = "API key required"
                         self.api_key_ctrl.Model.BackgroundColor = 0xFFFFFF
                         
+                    #AI! code moves here please
                     # Set endpoint field state
                     self.endpoint_ctrl.setEditable(needs_endpoint)
                     self.endpoint_ctrl.setEnable(needs_endpoint)

--- a/main.py
+++ b/main.py
@@ -400,14 +400,16 @@ class MainJob(unohelper.Base, XJobExecutor):
                         )
 
                     # Check if we can fetch available models
-                    has_credentials = (not needs_key or self.api_key_ctrl.getModel().Text) and \
-                                    (not needs_endpoint or self.endpoint_ctrl.getModel().Text)
-                    
-                    if has_credentials:
+                    get_model_args = {}
+                    if needs_key:
+                        get_model_args['api_key'] = self.api_key_ctrl.getModel().Text
+                    if needs_endpoint:
+                        get_model_args['api_base'] = self.endpoint_ctrl.getModel().Text
+                    if len(get_model_args) != 0:
                         try:
-                            models = provider_config.get_models()
+                            models = provider_config.get_models(**get_model_args)
                             if models:
-                                self.model_ctrl.removeItems(0, self.model_ctrl.getItemCount())
+                                self.model_ctrl.removeItems(0, self.model_ctrl.getItemCount()) #AI! we get an error from this call: Error fetching models: removeItems
                                 self.model_ctrl.addItems(sorted(models), 0)
                                 self.model_ctrl.Model.HelpText = f"Available models for {provider}"
                             else:

--- a/main.py
+++ b/main.py
@@ -515,7 +515,9 @@ class MainJob(unohelper.Base, XJobExecutor):
                         self.set_config("edit_selection_system_prompt", result["edit_selection_system_prompt"])
 
                     if "endpoint" in result and result["endpoint"].startswith("http"):
-                        self.set_config("endpoint", result["endpoint"])
+                        # Ensure endpoint ends with a single slash to match LiteLLM's behavior
+                        endpoint = result["endpoint"].rstrip('/') + '/'
+                        self.set_config("endpoint", endpoint)
 
                     if "model" in result:                
                         self.set_config("model", result["model"])
@@ -666,7 +668,9 @@ class MainJob(unohelper.Base, XJobExecutor):
                                     self.set_config("edit_selection_system_prompt", result["edit_selection_system_prompt"])
 
                                 if "endpoint" in result and result["endpoint"].startswith("http"):
-                                    self.set_config("endpoint", result["endpoint"])
+                                    # Ensure endpoint ends with a single slash to match LiteLLM's behavior
+                                    endpoint = result["endpoint"].rstrip('/') + '/'
+                                    self.set_config("endpoint", endpoint)
 
                                 if "model" in result:                
                                     self.set_config("model", result["model"])

--- a/main.py
+++ b/main.py
@@ -469,10 +469,13 @@ class MainJob(unohelper.Base, XJobExecutor):
                     print(f"Advanced state: {is_advanced}")
                     
                     current_selection = self.combo_provider.Model.Text
-                
-                print(f"Current selection: {current_selection}")
-                print(f"All providers: {all_providers}")
-                print(f"Local providers: {local_providers}")
+                    
+                    print(f"Current selection: {current_selection}")
+                    print(f"All providers: {all_providers}")
+                    print(f"Local providers: {local_providers}")
+                except Exception as e:
+                    print(f"Error in itemStateChanged: {str(e)}")
+                    return
                 
                 # Clear existing items
                 self.combo_provider.removeItems(0, self.combo_provider.getItemCount())

--- a/main.py
+++ b/main.py
@@ -351,15 +351,6 @@ class MainJob(unohelper.Base, XJobExecutor):
                         if api_base:
                             needs_endpoint = 'localhost' in api_base or '127.0.0.1' in api_base
                         
-                        #AI the code between here
-                        # Update endpoint field
-                        if needs_endpoint:
-                            self.endpoint_ctrl.Model.HelpText = f"Required endpoint (e.g. {api_base})"
-                            self.endpoint_ctrl.Model.BackgroundColor = 0xFFFFFF
-                        else:
-                            self.endpoint_ctrl.Model.HelpText = "Leave blank to use provider's default endpoint"
-                            self.endpoint_ctrl.Model.BackgroundColor = 0xEEEEEE
-                        #AI and here should move outside this try block and go after the api_key_ctrl GUI updates for consistency
                     except:
                         needs_key = True  # Fallback to requiring key if check fails
 
@@ -376,7 +367,14 @@ class MainJob(unohelper.Base, XJobExecutor):
                         self.api_key_ctrl.Model.HelpText = "API key required"
                         self.api_key_ctrl.Model.BackgroundColor = 0xFFFFFF
                         
-                    #AI! code moves here please
+                    # Update endpoint field
+                    if needs_endpoint:
+                        self.endpoint_ctrl.Model.HelpText = f"Required endpoint (e.g. {api_base})"
+                        self.endpoint_ctrl.Model.BackgroundColor = 0xFFFFFF
+                    else:
+                        self.endpoint_ctrl.Model.HelpText = "Leave blank to use provider's default endpoint"
+                        self.endpoint_ctrl.Model.BackgroundColor = 0xEEEEEE
+                    
                     # Set endpoint field state
                     self.endpoint_ctrl.setEditable(needs_endpoint)
                     self.endpoint_ctrl.setEnable(needs_endpoint)

--- a/main.py
+++ b/main.py
@@ -264,8 +264,8 @@ class MainJob(unohelper.Base, XJobExecutor):
         
         add("label_model", "FixedText", HORI_MARGIN, LABEL_HEIGHT*2 + VERT_MARGIN + VERT_SEP*2 + EDIT_HEIGHT*2, label_width, LABEL_HEIGHT, 
             {"Label": "Model (Required by Ollama):", "NoLabel": True})
-        add("edit_model", "Edit", HORI_MARGIN, LABEL_HEIGHT*3 + VERT_MARGIN + VERT_SEP*2 + EDIT_HEIGHT*2, 
-                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("model", ""))})
+        add("combo_model", "ComboBox", HORI_MARGIN, LABEL_HEIGHT*3 + VERT_MARGIN + VERT_SEP*2 + EDIT_HEIGHT*2, 
+                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Dropdown": True, "Text": str(self.get_config("model", ""))})
         
         add("label_endpoint", "FixedText", HORI_MARGIN, LABEL_HEIGHT*3 + VERT_MARGIN + VERT_SEP*3 + EDIT_HEIGHT*3, label_width, LABEL_HEIGHT, 
             {"Label": "Endpoint URL/Port (Local or Proxy, e.g., https://api.x.ai/v1/chat/completions for Grok):", "NoLabel": True})
@@ -446,14 +446,14 @@ class MainJob(unohelper.Base, XJobExecutor):
 
         # Set up provider change listener
         # Get all needed controls first
-        edit_model = dialog.getControl("edit_model")
+        combo_model = dialog.getControl("combo_model")
         
         provider_listener = ProviderChangeListener(
             edit_api_key, 
             api_key_label,
             edit_endpoint,
             endpoint_label,
-            edit_model
+            combo_model
         )
         combo_provider.addItemListener(provider_listener)
         
@@ -468,8 +468,8 @@ class MainJob(unohelper.Base, XJobExecutor):
         edit_api_key = dialog.getControl("edit_api_key")
         edit_api_key.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("api_key", "")))))
         
-        edit_model = dialog.getControl("edit_model")
-        edit_model.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("model", "")))))
+        combo_model = dialog.getControl("combo_model")
+        # No need for selection setting on ComboBox since we set the Text property
         
         edit_endpoint = dialog.getControl("edit_endpoint")
         edit_endpoint.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("endpoint", "http://127.0.0.1:5000")))))
@@ -541,7 +541,7 @@ class MainJob(unohelper.Base, XJobExecutor):
         if dialog.execute():
             result = {
                 "endpoint": edit_endpoint.getModel().Text,
-                "model": edit_model.getModel().Text,
+                "model": combo_model.Model.Text,
                 "provider": combo_provider.Model.Text,
                 "api_key": edit_api_key.getModel().Text,
                 "extend_selection_system_prompt": edit_extend_selection_system_prompt.getModel().Text,

--- a/main.py
+++ b/main.py
@@ -308,8 +308,18 @@ class MainJob(unohelper.Base, XJobExecutor):
             _y = ps.Height / 2 - HEIGHT / 2
         dialog.setPosSize(_x, _y, 0, 0, POS)
         
-        edit_provider = dialog.getControl("edit_provider")
-        edit_provider.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("provider", "")))))
+        combo_provider = dialog.getControl("combo_provider")
+        # Get known providers from LiteLLM
+        try:
+            import litellm
+            providers = sorted(litellm.provider_list)
+        except:
+            providers = ["openai", "ollama", "anthropic", "cohere", "huggingface", "replicate"]
+        
+        current_provider = str(self.get_config("provider", ""))
+        combo_provider.addItems(providers, 0)
+        if current_provider in providers:
+            combo_provider.Model.Text = current_provider
         
         edit_model = dialog.getControl("edit_model")
         edit_model.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("model", "")))))

--- a/main.py
+++ b/main.py
@@ -354,34 +354,40 @@ class MainJob(unohelper.Base, XJobExecutor):
                     except Exception as e:
                         print(f"Error checking provider config: {str(e)}")
 
-                    #AI! we have duplicated code here for api_key_ctrl and endpoint_ctrl.  Extract it into a local helper function that takes a widget and a help text string
+                    def update_widget_state(widget, is_required, help_text, example_text=None):
+                        """Helper to update widget state consistently"""
+                        if is_required:
+                            widget.Model.HelpText = help_text + (f" (e.g. {example_text})" if example_text else "")
+                            widget.Model.BackgroundColor = 0xFFFFFF
+                        else:
+                            widget.Model.HelpText = help_text
+                            widget.Model.BackgroundColor = 0xEEEEEE
+                        widget.setEditable(is_required)
+                        widget.setEnable(is_required)
+
                     # Update api_key state
                     if not needs_key:
                         print(f"Provider '{provider}' does NOT require API key")
-                        self.api_key_ctrl.Model.HelpText = "This provider doesn't require an API key"
-                        self.api_key_ctrl.Model.BackgroundColor = 0xEEEEEE
+                        update_widget_state(
+                            self.api_key_ctrl,
+                            False,
+                            "This provider doesn't require an API key"
+                        )
                     else:
                         print(f"Provider '{provider}' requires API key")
-                        self.api_key_ctrl.Model.HelpText = "API key required"
-                        self.api_key_ctrl.Model.BackgroundColor = 0xFFFFFF
-
-                    # Update api_key field state
-                    self.api_key_ctrl.setEditable(needs_key)
-                    self.api_key_ctrl.setEnable(needs_key)
+                        update_widget_state(
+                            self.api_key_ctrl,
+                            True,
+                            "API key required"
+                        )
                         
-                       
                     # Update endpoint field
-                    if needs_endpoint:
-                        self.endpoint_ctrl.Model.HelpText = f"Required endpoint (e.g. {api_base})"
-                        self.endpoint_ctrl.Model.BackgroundColor = 0xFFFFFF
-                    else:
-                        self.endpoint_ctrl.Model.HelpText = "Leave blank to use provider's default endpoint"
-                        self.endpoint_ctrl.Model.BackgroundColor = 0xEEEEEE
-                    
-                    # Set endpoint field state
-                    self.endpoint_ctrl.setEditable(needs_endpoint)
-                    self.endpoint_ctrl.setEnable(needs_endpoint)
-                    #AI: end duplicated code is here
+                    update_widget_state(
+                        self.endpoint_ctrl,
+                        needs_endpoint,
+                        "Leave blank to use provider's default endpoint",
+                        api_base if needs_endpoint else None
+                    )
                     
                 except Exception as e:
                     print(f"Error checking key requirement for {provider}: {str(e)}")

--- a/main.py
+++ b/main.py
@@ -380,9 +380,12 @@ class MainJob(unohelper.Base, XJobExecutor):
             def disposing(self, event):
                 pass
 
+        # Get all dialog controls first
         combo_provider = dialog.getControl("combo_provider")
         api_key_label = dialog.getControl("label_api_key")
         edit_api_key = dialog.getControl("edit_api_key")
+        edit_endpoint = dialog.getControl("edit_endpoint")
+        endpoint_label = dialog.getControl("label_endpoint")
         
         # Get known providers from LiteLLM
         try:
@@ -400,7 +403,7 @@ class MainJob(unohelper.Base, XJobExecutor):
             edit_api_key, 
             api_key_label,
             edit_endpoint,
-            dialog.getControl("label_endpoint")
+            endpoint_label
         )
         combo_provider.addItemListener(provider_listener)
         

--- a/main.py
+++ b/main.py
@@ -329,7 +329,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                 try:
                     # Turn on debug logging
                     import litellm
-                    litellm.set_verbose = True
+                    litellm._turn_on_debug()
                     print(f"Checking if provider '{provider}' requires API key...")
                     
                     # Test with empty key to see if provider requires one
@@ -353,7 +353,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                     print(f"Error checking key requirement for {provider}: {str(e)}")
                 finally:
                     # Turn off debug logging
-                    litellm.set_verbose = False
+                    litellm._turn_off_debug()
                     # Keep defaults (key required) if check fails
 
             def disposing(self, event):

--- a/main.py
+++ b/main.py
@@ -308,14 +308,14 @@ class MainJob(unohelper.Base, XJobExecutor):
             _y = ps.Height / 2 - HEIGHT / 2
         dialog.setPosSize(_x, _y, 0, 0, POS)
         
-        edit_endpoint = dialog.getControl("edit_endpoint")
-        edit_endpoint.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("endpoint", "http://127.0.0.1:5000")))))
+        edit_provider = dialog.getControl("edit_provider")
+        edit_provider.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("provider", "")))))
         
         edit_model = dialog.getControl("edit_model")
         edit_model.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("model", "")))))
         
-        edit_provider = dialog.getControl("edit_provider")
-        edit_provider.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("provider", "")))))
+        edit_endpoint = dialog.getControl("edit_endpoint")
+        edit_endpoint.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("endpoint", "http://127.0.0.1:5000")))))
         
         edit_api_key = dialog.getControl("edit_api_key")
         edit_api_key.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("api_key", "")))))

--- a/main.py
+++ b/main.py
@@ -460,11 +460,6 @@ class MainJob(unohelper.Base, XJobExecutor):
                 # Access the current selection
                 try:
                     user_input = self.input_box("Please enter edit instructions!", "Input", "")
-                    endpoint = self.get_config("endpoint", "http://127.0.0.1:5000")
-                    model_name = self.get_config("model", "")
-                    provider = self.get_config("provider", "")
-                    api_key = self.get_config("api_key", "")
-
                     messages = []
                     if self.get_config("edit_selection_system_prompt", "") != "":
                         messages.append({"role": "system", "content": self.get_config("edit_selection_system_prompt", "")})

--- a/main.py
+++ b/main.py
@@ -184,14 +184,12 @@ class MainJob(unohelper.Base, XJobExecutor):
         dialog.dispose()
         return ret
 
-    def settings_box(self,title="", x=None, y=None):
-        """ Shows dialog with input box.
-            @param message message to show on the dialog
+    def settings_box(self, title="", x=None, y=None):
+        """ Shows dialog with input box for settings.
             @param title window title
-            @param default default value
             @param x optional dialog position in twips
             @param y optional dialog position in twips
-            @return string if OK button pushed, otherwise zero length string
+            @return dictionary of settings if OK button pushed, otherwise empty dictionary
         """
         WIDTH = 600
         HORI_MARGIN = VERT_MARGIN = 8
@@ -199,9 +197,9 @@ class MainJob(unohelper.Base, XJobExecutor):
         BUTTON_HEIGHT = 26
         HORI_SEP = 8
         VERT_SEP = 4
-        LABEL_HEIGHT = BUTTON_HEIGHT  + 5
+        LABEL_HEIGHT = BUTTON_HEIGHT + 5
         EDIT_HEIGHT = 24
-        HEIGHT = VERT_MARGIN * 6 + LABEL_HEIGHT * 6 + VERT_SEP * 8 + EDIT_HEIGHT * 6
+        HEIGHT = VERT_MARGIN * 7 + LABEL_HEIGHT * 8 + VERT_SEP * 9 + EDIT_HEIGHT * 8
         import uno
         from com.sun.star.awt.PosSize import POS, SIZE, POSSIZE
         from com.sun.star.awt.PushButtonType import OK, CANCEL
@@ -224,38 +222,46 @@ class MainJob(unohelper.Base, XJobExecutor):
                 setattr(model, key, value)
         label_width = WIDTH - BUTTON_WIDTH - HORI_SEP - HORI_MARGIN * 2
         add("label_endpoint", "FixedText", HORI_MARGIN, VERT_MARGIN, label_width, LABEL_HEIGHT, 
-            {"Label": "Endpoint URL/Port:", "NoLabel": True})
+            {"Label": "Endpoint URL/Port (Local or Proxy):", "NoLabel": True})
         add("btn_ok", "Button", HORI_MARGIN + label_width + HORI_SEP, VERT_MARGIN, 
                 BUTTON_WIDTH, BUTTON_HEIGHT, {"PushButtonType": OK, "DefaultButton": True})
         add("edit_endpoint", "Edit", HORI_MARGIN, LABEL_HEIGHT,
-                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("endpoint","http://127.0.0.1:5000"))})
+                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("endpoint", "http://127.0.0.1:5000"))})
         
         add("label_model", "FixedText", HORI_MARGIN, LABEL_HEIGHT + VERT_MARGIN + VERT_SEP + EDIT_HEIGHT, label_width, LABEL_HEIGHT, 
             {"Label": "Model (Required by Ollama):", "NoLabel": True})
         add("edit_model", "Edit", HORI_MARGIN, LABEL_HEIGHT*2 + VERT_MARGIN + VERT_SEP*2 + EDIT_HEIGHT, 
-                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("model",""))})
+                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("model", ""))})
         
-        add("label_extend_selection_max_tokens", "FixedText", HORI_MARGIN, LABEL_HEIGHT*3 + VERT_MARGIN + VERT_SEP*3 + EDIT_HEIGHT, label_width, LABEL_HEIGHT, 
+        add("label_provider", "FixedText", HORI_MARGIN, LABEL_HEIGHT*3 + VERT_MARGIN + VERT_SEP*3 + EDIT_HEIGHT*2, label_width, LABEL_HEIGHT, 
+            {"Label": "Provider (e.g., openai, ollama, anthropic):", "NoLabel": True})
+        add("edit_provider", "Edit", HORI_MARGIN, LABEL_HEIGHT*4 + VERT_MARGIN + VERT_SEP*4 + EDIT_HEIGHT*2, 
+                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("provider", ""))})
+        
+        add("label_api_key", "FixedText", HORI_MARGIN, LABEL_HEIGHT*5 + VERT_MARGIN + VERT_SEP*5 + EDIT_HEIGHT*3, label_width, LABEL_HEIGHT, 
+            {"Label": "API Key (Optional, use with caution):", "NoLabel": True})
+        add("edit_api_key", "Edit", HORI_MARGIN, LABEL_HEIGHT*6 + VERT_MARGIN + VERT_SEP*6 + EDIT_HEIGHT*3, 
+                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("api_key", "")), "EchoChar": ord('*')})
+        
+        add("label_extend_selection_max_tokens", "FixedText", HORI_MARGIN, LABEL_HEIGHT*7 + VERT_MARGIN + VERT_SEP*7 + EDIT_HEIGHT*4, label_width, LABEL_HEIGHT, 
             {"Label": "Extend Selection Max Tokens:", "NoLabel": True})
-        add("edit_extend_selection_max_tokens", "Edit", HORI_MARGIN, LABEL_HEIGHT*4 + VERT_MARGIN + VERT_SEP*4 + EDIT_HEIGHT, 
-                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("extend_selection_max_tokens","70"))})
+        add("edit_extend_selection_max_tokens", "Edit", HORI_MARGIN, LABEL_HEIGHT*8 + VERT_MARGIN + VERT_SEP*8 + EDIT_HEIGHT*4, 
+                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("extend_selection_max_tokens", "70"))})
         
-        add("label_extend_selection_system_prompt", "FixedText", HORI_MARGIN, LABEL_HEIGHT*5 + VERT_MARGIN + VERT_SEP*5 + EDIT_HEIGHT, label_width, LABEL_HEIGHT, 
+        add("label_extend_selection_system_prompt", "FixedText", HORI_MARGIN, LABEL_HEIGHT*9 + VERT_MARGIN + VERT_SEP*9 + EDIT_HEIGHT*5, label_width, LABEL_HEIGHT, 
             {"Label": "Extend Selection System Prompt:", "NoLabel": True})
-        add("edit_extend_selection_system_prompt", "Edit", HORI_MARGIN, LABEL_HEIGHT*6 + VERT_MARGIN + VERT_SEP*6 + EDIT_HEIGHT, 
-                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("extend_selection_system_prompt",""))})
+        add("edit_extend_selection_system_prompt", "Edit", HORI_MARGIN, LABEL_HEIGHT*10 + VERT_MARGIN + VERT_SEP*10 + EDIT_HEIGHT*5, 
+                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("extend_selection_system_prompt", ""))})
 
-        add("label_edit_selection_max_new_tokens", "FixedText", HORI_MARGIN, LABEL_HEIGHT*7 + VERT_MARGIN + VERT_SEP*7 + EDIT_HEIGHT, label_width, LABEL_HEIGHT, 
+        add("label_edit_selection_max_new_tokens", "FixedText", HORI_MARGIN, LABEL_HEIGHT*11 + VERT_MARGIN + VERT_SEP*11 + EDIT_HEIGHT*6, label_width, LABEL_HEIGHT, 
             {"Label": "Edit Selection Max New Tokens:", "NoLabel": True})
-        add("edit_edit_selection_max_new_tokens", "Edit", HORI_MARGIN, LABEL_HEIGHT*8 + VERT_MARGIN + VERT_SEP*8 + EDIT_HEIGHT, 
-                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("edit_selection_max_new_tokens",""))})
+        add("edit_edit_selection_max_new_tokens", "Edit", HORI_MARGIN, LABEL_HEIGHT*12 + VERT_MARGIN + VERT_SEP*12 + EDIT_HEIGHT*6, 
+                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("edit_selection_max_new_tokens", "0"))})
 
-        add("label_edit_selection_system_prompt", "FixedText", HORI_MARGIN, LABEL_HEIGHT*9 + VERT_MARGIN + VERT_SEP*9 + EDIT_HEIGHT, label_width, LABEL_HEIGHT, 
+        add("label_edit_selection_system_prompt", "FixedText", HORI_MARGIN, LABEL_HEIGHT*13 + VERT_MARGIN + VERT_SEP*13 + EDIT_HEIGHT*7, label_width, LABEL_HEIGHT, 
             {"Label": "Edit Selection System Prompt:", "NoLabel": True})
-        add("edit_edit_selection_system_prompt", "Edit", HORI_MARGIN, LABEL_HEIGHT*10 + VERT_MARGIN + VERT_SEP*10 + EDIT_HEIGHT, 
-                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("edit_selection_system_prompt",""))})
-
-
+        add("edit_edit_selection_system_prompt", "Edit", HORI_MARGIN, LABEL_HEIGHT*14 + VERT_MARGIN + VERT_SEP*14 + EDIT_HEIGHT*7, 
+                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("edit_selection_system_prompt", ""))})
 
         frame = create("com.sun.star.frame.Desktop").getCurrentFrame()
         window = frame.getContainerWindow() if frame else None
@@ -270,35 +276,44 @@ class MainJob(unohelper.Base, XJobExecutor):
         dialog.setPosSize(_x, _y, 0, 0, POS)
         
         edit_endpoint = dialog.getControl("edit_endpoint")
-        edit_endpoint.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("endpoint","http://127.0.0.1:5000")))))
+        edit_endpoint.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("endpoint", "http://127.0.0.1:5000")))))
         
         edit_model = dialog.getControl("edit_model")
-        edit_model.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("model","")))))
-
+        edit_model.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("model", "")))))
+        
+        edit_provider = dialog.getControl("edit_provider")
+        edit_provider.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("provider", "")))))
+        
+        edit_api_key = dialog.getControl("edit_api_key")
+        edit_api_key.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("api_key", "")))))
+        
         edit_extend_selection_max_tokens = dialog.getControl("edit_extend_selection_max_tokens")
-        edit_extend_selection_max_tokens.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("extend_selection_max_tokens","70")))))
-
-
+        edit_extend_selection_max_tokens.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("extend_selection_max_tokens", "70")))))
+        
         edit_extend_selection_system_prompt = dialog.getControl("edit_extend_selection_system_prompt")
-        edit_extend_selection_system_prompt.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("extend_selection_system_prompt","")))))
-
-
+        edit_extend_selection_system_prompt.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("extend_selection_system_prompt", "")))))
+        
         edit_edit_selection_max_new_tokens = dialog.getControl("edit_edit_selection_max_new_tokens")
-        edit_edit_selection_max_new_tokens.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("edit_selection_max_new_tokens","0")))))
-
+        edit_edit_selection_max_new_tokens.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("edit_selection_max_new_tokens", "0")))))
+        
         edit_edit_selection_system_prompt = dialog.getControl("edit_edit_selection_system_prompt")
-        edit_edit_selection_system_prompt.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("edit_selection_system_prompt","")))))
-
-
+        edit_edit_selection_system_prompt.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("edit_selection_system_prompt", "")))))
+        
         edit_endpoint.setFocus()
 
         if dialog.execute():
-            result = {"endpoint":edit_endpoint.getModel().Text, "model": edit_model.getModel().Text, "extend_selection_system_prompt": edit_extend_selection_system_prompt.getModel().Text, "edit_selection_system_prompt": edit_edit_selection_system_prompt.getModel().Text}
+            result = {
+                "endpoint": edit_endpoint.getModel().Text,
+                "model": edit_model.getModel().Text,
+                "provider": edit_provider.getModel().Text,
+                "api_key": edit_api_key.getModel().Text,
+                "extend_selection_system_prompt": edit_extend_selection_system_prompt.getModel().Text,
+                "edit_selection_system_prompt": edit_edit_selection_system_prompt.getModel().Text
+            }
             if edit_extend_selection_max_tokens.getModel().Text.isdigit():
                 result["extend_selection_max_tokens"] = int(edit_extend_selection_max_tokens.getModel().Text)
             if edit_edit_selection_max_new_tokens.getModel().Text.isdigit():
                 result["edit_selection_max_new_tokens"] = int(edit_edit_selection_max_new_tokens.getModel().Text)
-
         else:
             result = {}
 
@@ -329,31 +344,39 @@ class MainJob(unohelper.Base, XJobExecutor):
                     try:
                         endpoint = self.get_config("endpoint", "http://127.0.0.1:5000")
                         model_name = self.get_config("model", "")
+                        provider = self.get_config("provider", "")
+                        api_key = self.get_config("api_key", "")
 
-                        prompt = None
+                        messages = []
                         if self.get_config("extend_selection_system_prompt", "") != "":
-                            prompt = "SYSTEM PROMPT\n" + self.get_config("extend_selection_system_prompt", "") + "\nEND SYSTEM PROMPT\n" + text_range.getString()
-                        else:
-                            prompt = text_range.getString()
-
-                        messages = [{"role": "user", "content": prompt}]
+                            messages.append({"role": "system", "content": self.get_config("extend_selection_system_prompt", "")})
+                        messages.append({"role": "user", "content": text_range.getString()})
                         
+                        # Construct model string based on provider if provided
+                        full_model = model_name
+                        if provider and model_name:
+                            full_model = f"{provider}/{model_name}"
+                        elif not model_name:
+                            full_model = "openai-compatible-model"
+
+                        kwargs = {
+                            "model": full_model,
+                            "messages": messages,
+                            "max_tokens": self.get_config("extend_selection_max_tokens", 70),
+                            "temperature": 1.0,
+                            "top_p": 0.9,
+                            "seed": 10,
+                            "api_base": endpoint
+                        }
+                        if api_key:
+                            kwargs["api_key"] = api_key
+
                         # Use LiteLLM completion API
-                        response = completion(
-                            model=model_name if model_name else f"openai/{endpoint}",
-                            messages=messages,
-                            max_tokens=self.get_config("extend_selection_max_tokens", 70),
-                            temperature=1,
-                            top_p=0.9,
-                            seed=10,
-                            base_url=endpoint if model_name else None
-                        )
+                        response = completion(**kwargs)
 
                         # Append completion to selection
                         selected_text = text_range.getString()
                         new_text = selected_text + response.choices[0].message.content
-
-                        # Set the new text
                         text_range.setString(new_text)
                 
                     except Exception as e:
@@ -364,32 +387,42 @@ class MainJob(unohelper.Base, XJobExecutor):
             elif args == "EditSelection":
                 # Access the current selection
                 try:
-                    user_input= self.input_box("Please enter edit instructions!", "Input", "")
+                    user_input = self.input_box("Please enter edit instructions!", "Input", "")
                     endpoint = self.get_config("endpoint", "http://127.0.0.1:5000")
                     model_name = self.get_config("model", "")
+                    provider = self.get_config("provider", "")
+                    api_key = self.get_config("api_key", "")
 
-                    prompt =  "ORIGINAL VERSION:\n" + text_range.getString() + "\n Below is an edited version according to the following instructions. There are no comments in the edited version. The edited version is followed by the end of the document. The original version will be edited as follows to create the edited versio:\n" + user_input + "\nEDITED VERSION:\n"
-
+                    messages = []
                     if self.get_config("edit_selection_system_prompt", "") != "":
-                        prompt = "SYSTEM PROMPT\n" + self.get_config("edit_selection_system_prompt","") + "\nEND SYSTEM PROMPT\n" + prompt
+                        messages.append({"role": "system", "content": self.get_config("edit_selection_system_prompt", "")})
+                    user_prompt = f"ORIGINAL VERSION:\n{text_range.getString()}\nBelow is an edited version according to the following instructions. There are no comments in the edited version.\nInstructions:\n{user_input}\nEDITED VERSION:"
+                    messages.append({"role": "user", "content": user_prompt})
 
-                    messages = [{"role": "user", "content": prompt}]
+                    # Construct model string based on provider if provided
+                    full_model = model_name
+                    if provider and model_name:
+                        full_model = f"{provider}/{model_name}"
+                    elif not model_name:
+                        full_model = "openai-compatible-model"
+
+                    kwargs = {
+                        "model": full_model,
+                        "messages": messages,
+                        "max_tokens": len(text_range.getString()) + self.get_config("edit_selection_max_new_tokens", 0),
+                        "temperature": 1.0,
+                        "top_p": 0.9,
+                        "seed": 10,
+                        "api_base": endpoint
+                    }
+                    if api_key:
+                        kwargs["api_key"] = api_key
 
                     # Use LiteLLM completion API
-                    response = completion(
-                        model=model_name if model_name else f"openai/{endpoint}",
-                        messages=messages,
-                        max_tokens=len(text_range.getString()) + self.get_config("edit_selection_max_new_tokens", 0),
-                        temperature=1,
-                        top_p=0.9,
-                        seed=10,
-                        base_url=endpoint if model_name else None
-                    )
+                    response = completion(**kwargs)
 
                     # Replace selection with completion
                     new_text = response.choices[0].message.content
-
-                    # Set the new text
                     text_range.setString(new_text)
 
                 except Exception as e:
@@ -418,10 +451,15 @@ class MainJob(unohelper.Base, XJobExecutor):
 
                     if "model" in result:                
                         self.set_config("model", result["model"])
+                        
+                    if "provider" in result:
+                        self.set_config("provider", result["provider"])
+                        
+                    if "api_key" in result:
+                        self.set_config("api_key", result["api_key"])
 
                 except Exception as e:
                     text_range = selection.getByIndex(0)
-                    # Append the user input to the selected text
                     text_range.setString(text_range.getString() + ":error: " + str(e))
         elif hasattr(model, "Sheets"):
             try:
@@ -458,54 +496,69 @@ class MainJob(unohelper.Base, XJobExecutor):
                             
                             if len(cell.getString()) > 0:
                                 try:
-                                    prompt = None
+                                    messages = []
                                     if self.get_config("extend_selection_system_prompt", "") != "":
-                                        prompt = "SYSTEM PROMPT\n" + self.get_config("extend_selection_system_prompt", "") + "\nEND SYSTEM PROMPT\n" + cell.getString()
-                                    else:
-                                        prompt = cell.getString()
-
-                                    messages = [{"role": "user", "content": prompt}]
+                                        messages.append({"role": "system", "content": self.get_config("extend_selection_system_prompt", "")})
+                                    messages.append({"role": "user", "content": cell.getString()})
                                     
+                                    # Construct model string based on provider if provided
+                                    full_model = model_name
+                                    if provider and model_name:
+                                        full_model = f"{provider}/{model_name}"
+                                    elif not model_name:
+                                        full_model = "openai-compatible-model"
+
+                                    kwargs = {
+                                        "model": full_model,
+                                        "messages": messages,
+                                        "max_tokens": self.get_config("extend_selection_max_tokens", 70),
+                                        "temperature": 1.0,
+                                        "top_p": 0.9,
+                                        "seed": 10,
+                                        "api_base": endpoint
+                                    }
+                                    if api_key:
+                                        kwargs["api_key"] = api_key
+
                                     # Use LiteLLM completion API
-                                    response = completion(
-                                        model=model_name if model_name else f"openai/{endpoint}",
-                                        messages=messages,
-                                        max_tokens=self.get_config("extend_selection_max_tokens", 70),
-                                        temperature=1,
-                                        top_p=0.9,
-                                        seed=10,
-                                        base_url=endpoint if model_name else None
-                                    )
+                                    response = completion(**kwargs)
 
                                     # Append completion to selection
                                     selected_text = cell.getString()
                                     new_text = selected_text + response.choices[0].message.content
-
-                                    # Set the new text
                                     cell.setString(new_text)
                                 except Exception as e:
-                                    # Append the user input to the selected text
                                     cell.setString(cell.getString() + ": " + str(e))
                         elif args == "EditSelection":
                             # Access the current selection
                             try:
-                                prompt =  "ORIGINAL VERSION:\n" + cell.getString() + "\n Below is an edited version according to the following instructions. Don't waste time thinking, be as fast as you can. There are no comments in the edited version. USER INSTRUCTIONS: \n" + user_input + "\nEDITED VERSION:\n"
-
+                                messages = []
                                 if self.get_config("edit_selection_system_prompt", "") != "":
-                                    prompt = "SYSTEM PROMPT\n" + self.get_config("edit_selection_system_prompt","") + "\nEND SYSTEM PROMPT\n" + prompt
+                                    messages.append({"role": "system", "content": self.get_config("edit_selection_system_prompt", "")})
+                                user_prompt = f"ORIGINAL VERSION:\n{cell.getString()}\nBelow is an edited version according to the following instructions. Don't waste time thinking, be as fast as you can. There are no comments in the edited version.\nInstructions:\n{user_input}\nEDITED VERSION:"
+                                messages.append({"role": "user", "content": user_prompt})
 
-                                messages = [{"role": "user", "content": prompt}]
+                                # Construct model string based on provider if provided
+                                full_model = model_name
+                                if provider and model_name:
+                                    full_model = f"{provider}/{model_name}"
+                                elif not model_name:
+                                    full_model = "openai-compatible-model"
+
+                                kwargs = {
+                                    "model": full_model,
+                                    "messages": messages,
+                                    "max_tokens": len(cell.getString()) + self.get_config("edit_selection_max_new_tokens", 0),
+                                    "temperature": 1.0,
+                                    "top_p": 0.9,
+                                    "seed": 10,
+                                    "api_base": endpoint
+                                }
+                                if api_key:
+                                    kwargs["api_key"] = api_key
 
                                 # Use LiteLLM completion API
-                                response = completion(
-                                    model=model_name if model_name else f"openai/{endpoint}",
-                                    messages=messages,
-                                    max_tokens=len(cell.getString()) + self.get_config("edit_selection_max_new_tokens", 0),
-                                    temperature=1,
-                                    top_p=0.9,
-                                    seed=10,
-                                    base_url=endpoint if model_name else None
-                                )
+                                response = completion(**kwargs)
 
                                 # Get previous selected text
                                 selected_text = cell.getString()
@@ -513,8 +566,6 @@ class MainJob(unohelper.Base, XJobExecutor):
 
                                 # Action, rather than thought
                                 new_text = re.sub(r'<think>.*?</think>', '', raw_response, flags=re.DOTALL)
-
-                                # Set the new text for the cell
                                 cell.setString(new_text)
 
                             except Exception as e:
@@ -542,9 +593,14 @@ class MainJob(unohelper.Base, XJobExecutor):
 
                                 if "model" in result:                
                                     self.set_config("model", result["model"])
+                                    
+                                if "provider" in result:
+                                    self.set_config("provider", result["provider"])
+                                    
+                                if "api_key" in result:
+                                    self.set_config("api_key", result["api_key"])
 
                             except Exception as e:
-                                # Append the user input to the selected text
                                 cell.setString(cell.getString() + ":error: " + str(e))
             except Exception as e:
                 pass

--- a/main.py
+++ b/main.py
@@ -351,7 +351,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                         if api_base:
                             needs_endpoint = 'localhost' in api_base or '127.0.0.1' in api_base
                         
-                    except:
+                    except: #AI! update this accept to just log the error. The needs_key var defaults to true so we don't need to set it here
                         needs_key = True  # Fallback to requiring key if check fails
 
                     if not needs_key:

--- a/main.py
+++ b/main.py
@@ -425,46 +425,7 @@ class MainJob(unohelper.Base, XJobExecutor):
 
             def disposing(self, event):
                 pass
-
-        # Get all dialog controls first
-        combo_provider = dialog.getControl("combo_provider")
-        api_key_label = dialog.getControl("label_api_key")
-        edit_api_key = dialog.getControl("edit_api_key")
-        edit_endpoint = dialog.getControl("edit_endpoint")
-        endpoint_label = dialog.getControl("label_endpoint")
-        
-        # Get known providers from LiteLLM
-        try:
-            providers = sorted(litellm.provider_list)
-        except:
-            providers = ["openai", "ollama", "anthropic", "cohere", "huggingface", "replicate"]
-        
-        current_provider = str(self.get_config("provider", ""))
-        combo_provider.addItems(providers, 0)
-        if current_provider in providers:
-            combo_provider.Model.Text = current_provider
-
-        # Set up provider change listener
-        # Get all needed controls first
-        combo_model = dialog.getControl("combo_model")
-        
-        provider_listener = ProviderChangeListener(
-            edit_api_key, 
-            api_key_label,
-            edit_endpoint,
-            endpoint_label,
-            combo_model
-        )
-        combo_provider.addItemListener(provider_listener)
-        
-        # Initialize state based on current provider
-        if current_provider:
-            # Create proper ItemEvent structure
-            item_event = uno.createUnoStruct("com.sun.star.awt.ItemEvent")
-            item_event.Source = combo_provider
-            item_event.Selected = 0  # Default selection index
-            provider_listener.itemStateChanged(item_event)
-        
+ 
         edit_api_key = dialog.getControl("edit_api_key")
         edit_api_key.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("api_key", "")))))
         
@@ -485,7 +446,33 @@ class MainJob(unohelper.Base, XJobExecutor):
         
         edit_edit_selection_system_prompt = dialog.getControl("edit_edit_selection_system_prompt")
         edit_edit_selection_system_prompt.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("edit_selection_system_prompt", "")))))
+ 
+        # Get known providers from LiteLLM
+        providers = sorted(litellm.provider_list)
         
+        current_provider = str(self.get_config("provider", ""))
+        combo_provider.addItems(providers, 0)
+        if current_provider in providers:
+            combo_provider.Model.Text = current_provider
+
+        # Set up provider change listener
+        provider_listener = ProviderChangeListener(
+            edit_api_key, 
+            api_key_label,
+            edit_endpoint,
+            endpoint_label,
+            combo_model
+        )
+        combo_provider.addItemListener(provider_listener)
+        
+        # Initialize state based on current provider
+        if current_provider:
+            # Create proper ItemEvent structure
+            item_event = uno.createUnoStruct("com.sun.star.awt.ItemEvent")
+            item_event.Source = combo_provider
+            item_event.Selected = 0  # Default selection index
+            provider_listener.itemStateChanged(item_event)
+              
         combo_provider.setFocus()
 
         # Add listener for test button using a UNO-compatible ActionListener

--- a/main.py
+++ b/main.py
@@ -258,17 +258,17 @@ class MainJob(unohelper.Base, XJobExecutor):
                 WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Dropdown": True})
         
         add("label_api_key", "FixedText", HORI_MARGIN, LABEL_HEIGHT + VERT_MARGIN + VERT_SEP + EDIT_HEIGHT, label_width, LABEL_HEIGHT, 
-            {"Label": "API Key (Optional, use with caution):", "NoLabel": True})
+            {"Label": "API Key:", "NoLabel": True})
         add("edit_api_key", "Edit", HORI_MARGIN, LABEL_HEIGHT*2 + VERT_MARGIN + VERT_SEP + EDIT_HEIGHT, 
                 WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("api_key", "")), "EchoChar": ord('*')})
         
         add("label_model", "FixedText", HORI_MARGIN, LABEL_HEIGHT*2 + VERT_MARGIN + VERT_SEP*2 + EDIT_HEIGHT*2, label_width, LABEL_HEIGHT, 
-            {"Label": "Model (Required by Ollama):", "NoLabel": True})
+            {"Label": "Model (Required):", "NoLabel": True})
         add("combo_model", "ComboBox", HORI_MARGIN, LABEL_HEIGHT*3 + VERT_MARGIN + VERT_SEP*2 + EDIT_HEIGHT*2, 
                 WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Dropdown": True, "Text": str(self.get_config("model", ""))})
         
         add("label_endpoint", "FixedText", HORI_MARGIN, LABEL_HEIGHT*3 + VERT_MARGIN + VERT_SEP*3 + EDIT_HEIGHT*3, label_width, LABEL_HEIGHT, 
-            {"Label": "Endpoint URL/Port (Local or Proxy, e.g., https://api.x.ai/v1/chat/completions for Grok):", "NoLabel": True})
+            {"Label": "Endpoint URL (if required by provider):", "NoLabel": True})
         add("edit_endpoint", "Edit", HORI_MARGIN, LABEL_HEIGHT*4 + VERT_MARGIN + VERT_SEP*3 + EDIT_HEIGHT*3, 
                 WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("endpoint", "http://127.0.0.1:5000"))})
         

--- a/main.py
+++ b/main.py
@@ -461,8 +461,13 @@ class MainJob(unohelper.Base, XJobExecutor):
                 self.combo_provider = combo_provider
             
             def itemStateChanged(self, event):
+                print(f"Advanced toggle state changed. Event State: {event.State}")
                 is_advanced = event.State == 1
                 current_selection = self.combo_provider.Model.Text
+                
+                print(f"Current selection: {current_selection}")
+                print(f"All providers: {all_providers}")
+                print(f"Local providers: {local_providers}")
                 
                 # Clear and repopulate based on advanced state
                 self.combo_provider.removeItems(0, self.combo_provider.getItemCount())
@@ -471,9 +476,15 @@ class MainJob(unohelper.Base, XJobExecutor):
                     p for p in all_providers if p in local_providers
                 ]
                 
+                print(f"New providers list: {providers}")
+                print(f"Adding {len(providers)} items to combo box")
+                
                 self.combo_provider.addItems(providers, 0)
                 if current_selection in providers:
+                    print(f"Restoring previous selection: {current_selection}")
                     self.combo_provider.Model.Text = current_selection
+                else:
+                    print("No valid previous selection to restore")
             
             def disposing(self, event):
                 pass
@@ -484,12 +495,20 @@ class MainJob(unohelper.Base, XJobExecutor):
         
         # Initial population based on advanced state
         current_provider = str(self.get_config("provider", ""))
-        initial_providers = all_providers if check_advanced.Model.State == 1 else [
+        initial_advanced_state = check_advanced.Model.State == 1
+        print(f"Initial advanced state: {initial_advanced_state}")
+        
+        initial_providers = all_providers if initial_advanced_state else [
             p for p in all_providers if p in local_providers
         ]
+        print(f"Initial providers list: {initial_providers}")
+        
         combo_provider.addItems(initial_providers, 0)
         if current_provider in initial_providers:
+            print(f"Setting initial provider: {current_provider}")
             combo_provider.Model.Text = current_provider
+        else:
+            print("No valid initial provider found")
 
         # Set up provider change listener
         provider_listener = ProviderChangeListener(

--- a/main.py
+++ b/main.py
@@ -370,11 +370,7 @@ class MainJob(unohelper.Base, XJobExecutor):
 
                     response = self.call_completion(
                         messages=[{"role": "user", "content": "Hello, are you working?"}],
-                        max_tokens=10,
-                        endpoint=endpoint,
-                        model_name=model_name,
-                        provider=provider,
-                        api_key=api_key
+                        max_tokens=10
                     )
                     self.result_ctrl.setText("Success: " + response.choices[0].message.content)
                 except Exception as e:
@@ -451,11 +447,7 @@ class MainJob(unohelper.Base, XJobExecutor):
 
                         response = self.call_completion(
                             messages=messages,
-                            max_tokens=self.get_config("extend_selection_max_tokens", 70),
-                            endpoint=endpoint,
-                            model_name=model_name,
-                            provider=provider,
-                            api_key=api_key
+                            max_tokens=self.get_config("extend_selection_max_tokens", 70)
                         )
 
                         # Append completion to selection
@@ -496,11 +488,7 @@ class MainJob(unohelper.Base, XJobExecutor):
 
                     response = self.call_completion(
                         messages=messages,
-                        max_tokens=len(text_range.getString()) + self.get_config("edit_selection_max_new_tokens", 0),
-                        endpoint=endpoint,
-                        model_name=model_name,
-                        provider=provider,
-                        api_key=api_key
+                        max_tokens=len(text_range.getString()) + self.get_config("edit_selection_max_new_tokens", 0)
                     )
 
                     # Replace selection with completion
@@ -598,11 +586,7 @@ class MainJob(unohelper.Base, XJobExecutor):
 
                                     response = self.call_completion(
                                         messages=messages,
-                                        max_tokens=self.get_config("extend_selection_max_tokens", 70),
-                                        endpoint=endpoint,
-                                        model_name=model_name,
-                                        provider=provider,
-                                        api_key=api_key
+                                        max_tokens=self.get_config("extend_selection_max_tokens", 70)
                                     )
 
                                     # Append completion to selection
@@ -634,11 +618,7 @@ class MainJob(unohelper.Base, XJobExecutor):
 
                                 response = self.call_completion(
                                     messages=messages,
-                                    max_tokens=len(cell.getString()) + self.get_config("edit_selection_max_new_tokens", 0),
-                                    endpoint=endpoint,
-                                    model_name=model_name,
-                                    provider=provider,
-                                    api_key=api_key
+                                    max_tokens=len(cell.getString()) + self.get_config("edit_selection_max_new_tokens", 0)
                                 )
 
                                 # Get previous selected text

--- a/main.py
+++ b/main.py
@@ -311,11 +311,9 @@ class MainJob(unohelper.Base, XJobExecutor):
         
         # Add provider change listener
         class ProviderChangeListener(unohelper.Base, XItemListener):
-            def __init__(self, api_key_ctrl, api_key_label, endpoint_ctrl, endpoint_label, model_ctrl):
+            def __init__(self, api_key_ctrl, endpoint_ctrl, model_ctrl):
                 self.api_key_ctrl = api_key_ctrl
-                self.api_key_label = api_key_label
                 self.endpoint_ctrl = endpoint_ctrl
-                self.endpoint_label = endpoint_label
                 self.model_ctrl = model_ctrl
                 self.api_key_ctrl.Model.HelpText = "Leave blank if not required for your provider"
                 self.endpoint_ctrl.Model.HelpText = "Leave blank to use default endpoint"
@@ -409,7 +407,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                         try:
                             models = provider_config.get_models(**get_model_args)
                             if models:
-                                self.model_ctrl.removeItems(0, self.model_ctrl.getItemCount()) #AI! we get an error from this call: Error fetching models: removeItems
+                                self.model_ctrl.removeItems(0, self.model_ctrl.getItemCount())
                                 self.model_ctrl.addItems(sorted(models), 0)
                                 self.model_ctrl.Model.HelpText = f"Available models for {provider}"
                             else:
@@ -426,6 +424,9 @@ class MainJob(unohelper.Base, XJobExecutor):
             def disposing(self, event):
                 pass
  
+        combo_provider = dialog.getControl("combo_provider")
+        # No need for selection setting on ComboBox since we set the Text property
+
         edit_api_key = dialog.getControl("edit_api_key")
         edit_api_key.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("api_key", "")))))
         
@@ -458,9 +459,7 @@ class MainJob(unohelper.Base, XJobExecutor):
         # Set up provider change listener
         provider_listener = ProviderChangeListener(
             edit_api_key, 
-            api_key_label,
             edit_endpoint,
-            endpoint_label,
             combo_model
         )
         combo_provider.addItemListener(provider_listener)
@@ -478,14 +477,13 @@ class MainJob(unohelper.Base, XJobExecutor):
         # Add listener for test button using a UNO-compatible ActionListener
         from com.sun.star.awt import XActionListener
         class TestConnectionListener(unohelper.Base, XActionListener):
-            def __init__(self, endpoint_ctrl, model_ctrl, provider_ctrl, api_key_ctrl, result_ctrl, main_job, api_key_label):
+            def __init__(self, endpoint_ctrl, model_ctrl, provider_ctrl, api_key_ctrl, result_ctrl, main_job):
                 self.endpoint_ctrl = endpoint_ctrl
                 self.model_ctrl = model_ctrl
                 self.provider_ctrl = provider_ctrl
                 self.api_key_ctrl = api_key_ctrl
                 self.result_ctrl = result_ctrl
                 self.main_job = main_job
-                self.api_key_label = api_key_label
 
             def disposing(self, source):
                 pass
@@ -520,8 +518,7 @@ class MainJob(unohelper.Base, XJobExecutor):
             combo_provider,
             edit_api_key,
             dialog.getControl("test_result"),
-            self,
-            api_key_label
+            self
         )
         btn_test.addActionListener(test_listener)
 

--- a/main.py
+++ b/main.py
@@ -382,12 +382,21 @@ class MainJob(unohelper.Base, XJobExecutor):
                         )
                         
                     # Update endpoint field
-                    update_widget_state(
-                        self.endpoint_ctrl,
-                        needs_endpoint,
-                        "Leave blank to use provider's default endpoint",
-                        api_base if needs_endpoint else None
-                    )
+                    if needs_endpoint:
+                        print(f"Provider '{provider}' requires custom endpoint")
+                        update_widget_state(
+                            self.endpoint_ctrl,
+                            True,
+                            "Endpoint required (e.g. " + api_base + ")",
+                            api_base
+                        )
+                    else:
+                        print(f"Provider '{provider}' uses default endpoint")
+                        update_widget_state(
+                            self.endpoint_ctrl,
+                            False,
+                            "Uses provider's default endpoint"
+                        )
                     
                 except Exception as e:
                     print(f"Error checking key requirement for {provider}: {str(e)}")

--- a/main.py
+++ b/main.py
@@ -320,30 +320,27 @@ class MainJob(unohelper.Base, XJobExecutor):
                 if not provider:
                     return
                 
+                # Default to requiring key until we know otherwise
+                self.api_key_ctrl.setEditable(True)
+                self.api_key_ctrl.setEnable(True)
+                self.api_key_ctrl.Model.HelpText = "API key (required for most providers)"
+                self.api_key_ctrl.Model.BackgroundColor = 0xFFFFFF
+                
                 try:
                     # Test with empty key to see if provider requires one
-                    requires_key = not check_valid_key(
+                    if check_valid_key(
                         model=f"{provider}/dummy-model",  # dummy model name
                         api_key=""
-                    )
-                    
-                    self.api_key_ctrl.setEditable(requires_key)
-                    self.api_key_ctrl.setEnable(requires_key)
-                    self.api_key_ctrl.Model.HelpText = (
-                        "API key required for this provider" if requires_key 
-                        else "This provider typically doesn't require an API key"
-                    )
-                    
-                    # Visual indication
-                    self.api_key_ctrl.Model.BackgroundColor = (
-                        0xEEEEEE if not requires_key else 0xFFFFFF  # Grey if not needed
-                    )
+                    ):
+                        # If check passes with empty key, provider doesn't need one
+                        self.api_key_ctrl.setEditable(False)
+                        self.api_key_ctrl.setEnable(False)
+                        self.api_key_ctrl.Model.HelpText = "This provider doesn't require an API key"
+                        self.api_key_ctrl.Model.BackgroundColor = 0xEEEEEE
                     
                 except Exception as e:
-                    # Fallback - assume key might be needed
                     print(f"Error checking key requirement: {str(e)}")
-                    self.api_key_ctrl.setEditable(True)
-                    self.api_key_ctrl.Model.BackgroundColor = 0xFFFFFF
+                    # Keep defaults (key required) if check fails
 
             def disposing(self, event):
                 pass

--- a/main.py
+++ b/main.py
@@ -367,12 +367,11 @@ class MainJob(unohelper.Base, XJobExecutor):
         
         # Initialize state based on current provider
         if current_provider:
-            provider_listener.itemStateChanged(
-                uno.createUnoStruct("com.sun.star.awt.ItemEvent",
-                    Source=combo_provider,
-                    SelectedItem=current_provider
-                )
-            )
+            # Create proper ItemEvent structure
+            item_event = uno.createUnoStruct("com.sun.star.awt.ItemEvent")
+            item_event.Source = combo_provider
+            item_event.Selected = 0  # Default selection index
+            provider_listener.itemStateChanged(item_event)
         
         edit_api_key = dialog.getControl("edit_api_key")
         edit_api_key.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("api_key", "")))))

--- a/main.py
+++ b/main.py
@@ -341,8 +341,8 @@ class MainJob(unohelper.Base, XJobExecutor):
                     kwargs = {
                         "model": full_model,
                         "messages": [{"role": "user", "content": "Hello, are you working?"}],
-                        "max_tokens": 10,
-                        "temperature": 0.7
+                        "max_tokens": 10
+                        # Note: May want to add temperature parameter later for test calls
                     }
                     # Only include api_base if endpoint is not empty
                     if endpoint:
@@ -437,10 +437,8 @@ class MainJob(unohelper.Base, XJobExecutor):
                         kwargs = {
                             "model": full_model,
                             "messages": messages,
-                            "max_tokens": self.get_config("extend_selection_max_tokens", 70),
-                            "temperature": 1.0,
-                            "top_p": 0.9,
-                            "seed": 10
+                            "max_tokens": self.get_config("extend_selection_max_tokens", 70)
+                            # Note: May want to add temperature/top_p/seed parameters later for finer control
                         }
                         # Only include api_base if endpoint is not empty
                         if endpoint:
@@ -490,10 +488,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                     kwargs = {
                         "model": full_model,
                         "messages": messages,
-                        "max_tokens": len(text_range.getString()) + self.get_config("edit_selection_max_new_tokens", 0),
-                        "temperature": 1.0,
-                        "top_p": 0.9,
-                        "seed": 10
+                        "max_tokens": len(text_range.getString()) + self.get_config("edit_selection_max_new_tokens", 0)
                     }
                     # Only include api_base if endpoint is not empty
                     if endpoint:
@@ -600,10 +595,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                                     kwargs = {
                                         "model": full_model,
                                         "messages": messages,
-                                        "max_tokens": self.get_config("extend_selection_max_tokens", 70),
-                                        "temperature": 1.0,
-                                        "top_p": 0.9,
-                                        "seed": 10
+                                        "max_tokens": self.get_config("extend_selection_max_tokens", 70)
                                     }
                                     # Only include api_base if endpoint is not empty
                                     if endpoint:
@@ -644,10 +636,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                                 kwargs = {
                                     "model": full_model,
                                     "messages": messages,
-                                    "max_tokens": len(cell.getString()) + self.get_config("edit_selection_max_new_tokens", 0),
-                                    "temperature": 1.0,
-                                    "top_p": 0.9,
-                                    "seed": 10
+                                    "max_tokens": len(cell.getString()) + self.get_config("edit_selection_max_new_tokens", 0)
                                 }
                                 # Only include api_base if endpoint is not empty
                                 if endpoint:

--- a/main.py
+++ b/main.py
@@ -451,7 +451,21 @@ class MainJob(unohelper.Base, XJobExecutor):
         edit_edit_selection_system_prompt.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("edit_selection_system_prompt", "")))))
  
         # Define local providers
-        local_providers = ["ollama", "llamafile", "text-generation-webui", "vllm", "openai-compatible"]
+        local_providers = [
+            "ollama", 
+            "llamafile",
+            "text-generation-webui",
+            "vllm",
+            "openai-compatible",
+            "lm_studio",
+            "oobabooga",
+            "xinference",
+            "hosted_vllm",
+            "custom",
+            "custom_openai",
+            "openai_like",
+            "litellm_proxy"
+        ]
         
         # Get known providers from LiteLLM
         all_providers = sorted(litellm.provider_list)

--- a/main.py
+++ b/main.py
@@ -345,7 +345,9 @@ class MainJob(unohelper.Base, XJobExecutor):
                         
                         if hasattr(provider_config, 'get_api_key'):
                             try:
-                                needs_key = provider_config.get_api_key('needed') == 'needed'
+                                _needs_key = provider_config.get_api_key('needed') 
+                                print(f"Provider key needed: {_needs_key}")
+                                needs_key = str(_needs_key) == 'needed'
                             except Exception as e:
                                 print(f"Error checking API key requirement: {str(e)}")
                                 # Keep default of requiring key
@@ -470,17 +472,17 @@ class MainJob(unohelper.Base, XJobExecutor):
         local_providers = [
             "ollama", 
             "llamafile",
-            "text-generation-webui",
-            "vllm",
-            "openai-compatible",
+            #"text-generation-webui",
+            #"vllm",
+            #"openai-compatible",
             "lm_studio",
-            "oobabooga",
-            "xinference",
-            "hosted_vllm",
-            "custom",
-            "custom_openai",
-            "openai_like",
-            "litellm_proxy"
+            #"oobabooga",
+            #"xinference",
+            #"hosted_vllm",
+            #"custom",
+            #"custom_openai",
+            #"openai_like",
+            #"litellm_proxy"
         ]
         
         # Get known providers from LiteLLM

--- a/main.py
+++ b/main.py
@@ -342,15 +342,15 @@ class MainJob(unohelper.Base, XJobExecutor):
                         "model": full_model,
                         "messages": [{"role": "user", "content": "Hello, are you working?"}],
                         "max_tokens": 10,
-                        "temperature": 0.7,
-                        "api_base": endpoint
+                        "temperature": 0.7
                     }
+                    # Only include api_base if endpoint is not empty
+                    if endpoint:
+                        kwargs["api_base"] = endpoint
                     if api_key:
                         kwargs["api_key"] = api_key
 
-                    #AI: the comment below shows what args need to look like for success with xai
-                    #AI: the biggest difference I believe is that we shouldn't pass api_base when the field in settings is empty
-                    #AI! update all completion calls to correct this issue
+                    # Example args for xai/grok-3-latest:
                     #kwargs = {
                     #        'model': "xai/grok-3-latest",
                     #        'messages': [ {
@@ -440,9 +440,11 @@ class MainJob(unohelper.Base, XJobExecutor):
                             "max_tokens": self.get_config("extend_selection_max_tokens", 70),
                             "temperature": 1.0,
                             "top_p": 0.9,
-                            "seed": 10,
-                            "api_base": endpoint
+                            "seed": 10
                         }
+                        # Only include api_base if endpoint is not empty
+                        if endpoint:
+                            kwargs["api_base"] = endpoint
                         if api_key:
                             kwargs["api_key"] = api_key
 
@@ -491,9 +493,11 @@ class MainJob(unohelper.Base, XJobExecutor):
                         "max_tokens": len(text_range.getString()) + self.get_config("edit_selection_max_new_tokens", 0),
                         "temperature": 1.0,
                         "top_p": 0.9,
-                        "seed": 10,
-                        "api_base": endpoint
+                        "seed": 10
                     }
+                    # Only include api_base if endpoint is not empty
+                    if endpoint:
+                        kwargs["api_base"] = endpoint
                     if api_key:
                         kwargs["api_key"] = api_key
 
@@ -599,9 +603,11 @@ class MainJob(unohelper.Base, XJobExecutor):
                                         "max_tokens": self.get_config("extend_selection_max_tokens", 70),
                                         "temperature": 1.0,
                                         "top_p": 0.9,
-                                        "seed": 10,
-                                        "api_base": endpoint
+                                        "seed": 10
                                     }
+                                    # Only include api_base if endpoint is not empty
+                                    if endpoint:
+                                        kwargs["api_base"] = endpoint
                                     if api_key:
                                         kwargs["api_key"] = api_key
 
@@ -641,9 +647,11 @@ class MainJob(unohelper.Base, XJobExecutor):
                                     "max_tokens": len(cell.getString()) + self.get_config("edit_selection_max_new_tokens", 0),
                                     "temperature": 1.0,
                                     "top_p": 0.9,
-                                    "seed": 10,
-                                    "api_base": endpoint
+                                    "seed": 10
                                 }
+                                # Only include api_base if endpoint is not empty
+                                if endpoint:
+                                    kwargs["api_base"] = endpoint
                                 if api_key:
                                     kwargs["api_key"] = api_key
 

--- a/main.py
+++ b/main.py
@@ -425,11 +425,6 @@ class MainJob(unohelper.Base, XJobExecutor):
                     # Get the first range of the selection
                     #text_range = selection.getByIndex(0)
                     try:
-                        endpoint = self.get_config("endpoint", "http://127.0.0.1:5000")
-                        model_name = self.get_config("model", "")
-                        provider = self.get_config("provider", "")
-                        api_key = self.get_config("api_key", "")
-
                         messages = []
                         if self.get_config("extend_selection_system_prompt", "") != "":
                             messages.append({"role": "system", "content": self.get_config("extend_selection_system_prompt", "")})

--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ class MainJob(unohelper.Base, XJobExecutor):
             get_config_func = self.get_config
         try:
             # Construct model string based on provider if provided
+            provider = provider or get_config_func("provider", "")
             full_model = model_name or get_config_func("model", "")
             if provider and full_model:
                 full_model = f"{provider}/{full_model}"

--- a/main.py
+++ b/main.py
@@ -503,12 +503,14 @@ class MainJob(unohelper.Base, XJobExecutor):
                     print("No previous selection to restore")
             
             def disposing(self, event):
-                print("AdvancedToggleListener disposed")
+                print(f"AdvancedToggleListener disposing. Event: {event}")
+                # Don't actually dispose - we want to keep the listener active
 
         # Create and register advanced toggle listener first
         check_advanced = dialog.getControl("check_advanced")
-        advanced_listener = AdvancedToggleListener(combo_provider)
-        check_advanced.addItemListener(advanced_listener)
+        self._advanced_listener = AdvancedToggleListener(combo_provider)  # Keep reference to prevent GC
+        check_advanced.addItemListener(self._advanced_listener)
+        print(f"Listener registered. Active listeners: {check_advanced.getItemListeners()}")
         
         # Debug checkbox state
         print(f"Checkbox initial state: {check_advanced.Model.State}")
@@ -636,7 +638,8 @@ class MainJob(unohelper.Base, XJobExecutor):
         else:
             result = {}
 
-        dialog.dispose()
+        # Don't dispose the listener - let it be garbage collected naturally
+        # dialog.dispose() will handle cleanup
         return result
     #end sharealike section 
 

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import json
 import urllib.request
 import urllib.parse
 from com.sun.star.task import XJobExecutor
-from com.sun.star.awt import MessageBoxButtons as MSG_BUTTONS, XItemListener
+from com.sun.star.awt import MessageBoxButtons as MSG_BUTTONS, XItemListener, XActionListener
 import uno
 import os 
 import logging
@@ -456,8 +456,6 @@ class MainJob(unohelper.Base, XJobExecutor):
         # Get known providers from LiteLLM
         all_providers = sorted(litellm.provider_list)
         
-        # Add listener for advanced checkbox
-        from com.sun.star.awt import XItemListener
         class AdvancedToggleListener(unohelper.Base, XItemListener):
             def __init__(self, combo_provider):
                 self.combo_provider = combo_provider

--- a/main.py
+++ b/main.py
@@ -354,19 +354,22 @@ class MainJob(unohelper.Base, XJobExecutor):
                     except Exception as e:
                         print(f"Error checking provider config: {str(e)}")
 
+                    #AI! we have duplicated code here for api_key_ctrl and endpoint_ctrl.  Extract it into a local helper function that takes a widget and a help text string
+                    # Update api_key state
                     if not needs_key:
                         print(f"Provider '{provider}' does NOT require API key")
-                        self.api_key_ctrl.setEditable(False)
-                        self.api_key_ctrl.setEnable(False)
                         self.api_key_ctrl.Model.HelpText = "This provider doesn't require an API key"
                         self.api_key_ctrl.Model.BackgroundColor = 0xEEEEEE
                     else:
                         print(f"Provider '{provider}' requires API key")
-                        self.api_key_ctrl.setEditable(True)
-                        self.api_key_ctrl.setEnable(True)
                         self.api_key_ctrl.Model.HelpText = "API key required"
                         self.api_key_ctrl.Model.BackgroundColor = 0xFFFFFF
+
+                    # Update api_key field state
+                    self.api_key_ctrl.setEditable(needs_key)
+                    self.api_key_ctrl.setEnable(needs_key)
                         
+                       
                     # Update endpoint field
                     if needs_endpoint:
                         self.endpoint_ctrl.Model.HelpText = f"Required endpoint (e.g. {api_base})"
@@ -378,6 +381,7 @@ class MainJob(unohelper.Base, XJobExecutor):
                     # Set endpoint field state
                     self.endpoint_ctrl.setEditable(needs_endpoint)
                     self.endpoint_ctrl.setEnable(needs_endpoint)
+                    #AI: end duplicated code is here
                     
                 except Exception as e:
                     print(f"Error checking key requirement for {provider}: {str(e)}")

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ import re
 try:
     sys.path.append(os.path.join(os.path.dirname(__file__), 'lib'))
     from litellm import completion, check_valid_key
+    import litellm
 except ImportError:
     # Fallback or error handling if LiteLLM is not available
     def completion(*args, **kwargs):
@@ -328,7 +329,6 @@ class MainJob(unohelper.Base, XJobExecutor):
                 
                 try:
                     # Turn on debug logging
-                    import litellm
                     litellm._turn_on_debug()
                     print(f"Checking if provider '{provider}' requires API key...")
                     
@@ -351,10 +351,6 @@ class MainJob(unohelper.Base, XJobExecutor):
                     
                 except Exception as e:
                     print(f"Error checking key requirement for {provider}: {str(e)}")
-                finally:
-                    # Turn off debug logging
-                    litellm._turn_off_debug()
-                    # Keep defaults (key required) if check fails
 
             def disposing(self, event):
                 pass
@@ -365,7 +361,6 @@ class MainJob(unohelper.Base, XJobExecutor):
         
         # Get known providers from LiteLLM
         try:
-            import litellm
             providers = sorted(litellm.provider_list)
         except:
             providers = ["openai", "ollama", "anthropic", "cohere", "huggingface", "replicate"]
@@ -432,7 +427,6 @@ class MainJob(unohelper.Base, XJobExecutor):
                 api_key = self.api_key_ctrl.getModel().Text
                 try:
                     # Turn on debug for this test call
-                    import litellm
                     litellm._turn_on_debug()
 
                     response = self.main_job.call_completion(
@@ -448,9 +442,6 @@ class MainJob(unohelper.Base, XJobExecutor):
                 except Exception as e:
                     self.result_ctrl.setText("Failed: " + str(e))
                     print(f"Test Connection Error: {str(e)}")
-                finally:
-                    # Turn off debug after the test call
-                    litellm._turn_off_debug()
 
         btn_test = dialog.getControl("btn_test")
         test_listener = TestConnectionListener(

--- a/main.py
+++ b/main.py
@@ -464,16 +464,11 @@ class MainJob(unohelper.Base, XJobExecutor):
             def itemStateChanged(self, event):
                 try:
                     print(f"\nAdvanced toggle state changed. Source: {event.Source}")
-                    print(f"Event State: {event.State}")
-                    if hasattr(event.Source, 'Model') and hasattr(event.Source.Model, 'State'):
-                        print(f"Event Source Model State: {event.Source.Model.State}")
-                    else:
-                        print("Could not access Source.Model.State")
-                except Exception as e:
-                    print(f"Error in itemStateChanged: {str(e)}")
-                
-                is_advanced = event.State == 1
-                current_selection = self.combo_provider.Model.Text
+                    # Get state from the checkbox model directly
+                    is_advanced = event.Source.Model.State == 1
+                    print(f"Advanced state: {is_advanced}")
+                    
+                    current_selection = self.combo_provider.Model.Text
                 
                 print(f"Current selection: {current_selection}")
                 print(f"All providers: {all_providers}")
@@ -483,10 +478,12 @@ class MainJob(unohelper.Base, XJobExecutor):
                 self.combo_provider.removeItems(0, self.combo_provider.getItemCount())
                 
                 # Filter providers based on advanced state
-                providers = all_providers if is_advanced else [
-                    p for p in all_providers 
-                    if p.value in local_providers
-                ]
+                if is_advanced:
+                    providers = all_providers
+                    print("Showing ALL providers")
+                else:
+                    providers = [p for p in all_providers if p.value in local_providers]
+                    print(f"Showing LOCAL providers only: {[p.value for p in providers]}")
                 
                 print(f"Filtered providers count: {len(providers)}")
                 print(f"First 5 providers: {providers[:5]}")
@@ -503,10 +500,17 @@ class MainJob(unohelper.Base, XJobExecutor):
                             self.combo_provider.Model.Text = current_selection
                         else:
                             print(f"Previous selection {current_selection} not in filtered list")
+                            # Select first item if previous selection not available
+                            if providers:
+                                self.combo_provider.Model.Text = providers[0].value
                     except ValueError:
                         print(f"Invalid previous selection: {current_selection}")
+                        if providers:
+                            self.combo_provider.Model.Text = providers[0].value
                 else:
                     print("No previous selection to restore")
+                    if providers:
+                        self.combo_provider.Model.Text = providers[0].value
             
             def disposing(self, event):
                 print(f"AdvancedToggleListener disposing. Event: {event}")

--- a/main.py
+++ b/main.py
@@ -342,7 +342,7 @@ class MainJob(unohelper.Base, XJobExecutor):
         edit_edit_selection_system_prompt = dialog.getControl("edit_edit_selection_system_prompt")
         edit_edit_selection_system_prompt.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("edit_selection_system_prompt", "")))))
         
-        edit_provider.setFocus()
+        combo_provider.setFocus()
 
         # Add listener for test button using a UNO-compatible ActionListener
         from com.sun.star.awt import XActionListener

--- a/main.py
+++ b/main.py
@@ -443,6 +443,9 @@ class MainJob(unohelper.Base, XJobExecutor):
             combo_provider.Model.Text = current_provider
 
         # Set up provider change listener
+        # Get all needed controls first
+        edit_model = dialog.getControl("edit_model")
+        
         provider_listener = ProviderChangeListener(
             edit_api_key, 
             api_key_label,

--- a/main.py
+++ b/main.py
@@ -399,13 +399,14 @@ class MainJob(unohelper.Base, XJobExecutor):
         # Add listener for test button using a UNO-compatible ActionListener
         from com.sun.star.awt import XActionListener
         class TestConnectionListener(unohelper.Base, XActionListener):
-            def __init__(self, endpoint_ctrl, model_ctrl, provider_ctrl, api_key_ctrl, result_ctrl, main_job):
+            def __init__(self, endpoint_ctrl, model_ctrl, provider_ctrl, api_key_ctrl, result_ctrl, main_job, api_key_label):
                 self.endpoint_ctrl = endpoint_ctrl
                 self.model_ctrl = model_ctrl
                 self.provider_ctrl = provider_ctrl
                 self.api_key_ctrl = api_key_ctrl
                 self.result_ctrl = result_ctrl
                 self.main_job = main_job
+                self.api_key_label = api_key_label
 
             def disposing(self, source):
                 pass
@@ -438,7 +439,15 @@ class MainJob(unohelper.Base, XJobExecutor):
                     litellm._turn_off_debug()
 
         btn_test = dialog.getControl("btn_test")
-        test_listener = TestConnectionListener(edit_endpoint, edit_model, combo_provider, edit_api_key, dialog.getControl("test_result"), self, api_key_label)
+        test_listener = TestConnectionListener(
+            edit_endpoint,
+            edit_model, 
+            combo_provider,
+            edit_api_key,
+            dialog.getControl("test_result"),
+            self,
+            api_key_label
+        )
         btn_test.addActionListener(test_listener)
 
         if dialog.execute():

--- a/main.py
+++ b/main.py
@@ -251,10 +251,10 @@ class MainJob(unohelper.Base, XJobExecutor):
         add("btn_ok", "Button", HORI_MARGIN + label_width + HORI_SEP, VERT_MARGIN, 
                 BUTTON_WIDTH, BUTTON_HEIGHT, {"PushButtonType": OK, "DefaultButton": True})
 
-        add("label_provider", "FixedText", HORI_MARGIN, VERT_MARGIN, label_width, LABEL_HEIGHT, 
-            {"Label": "Provider (e.g., openai, ollama, anthropic):", "NoLabel": True})
-        add("edit_provider", "Edit", HORI_MARGIN, LABEL_HEIGHT + VERT_MARGIN, 
-                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("provider", ""))})
+        add("label_provider", "FixedText", HORI_MARGIN, VERT_MARGIN, label_width, LABEL_HEIGHT,
+            {"Label": "Provider:", "NoLabel": True})
+        add("combo_provider", "ComboBox", HORI_MARGIN, LABEL_HEIGHT + VERT_MARGIN,
+                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Dropdown": True})
         
         add("label_model", "FixedText", HORI_MARGIN, LABEL_HEIGHT + VERT_MARGIN + VERT_SEP + EDIT_HEIGHT, label_width, LABEL_HEIGHT, 
             {"Label": "Model (Required by Ollama):", "NoLabel": True})
@@ -376,14 +376,14 @@ class MainJob(unohelper.Base, XJobExecutor):
                     litellm._turn_off_debug()
 
         btn_test = dialog.getControl("btn_test")
-        test_listener = TestConnectionListener(edit_endpoint, edit_model, edit_provider, edit_api_key, dialog.getControl("test_result"), self)
+        test_listener = TestConnectionListener(edit_endpoint, edit_model, combo_provider, edit_api_key, dialog.getControl("test_result"), self)
         btn_test.addActionListener(test_listener)
 
         if dialog.execute():
             result = {
                 "endpoint": edit_endpoint.getModel().Text,
                 "model": edit_model.getModel().Text,
-                "provider": edit_provider.getModel().Text,
+                "provider": combo_provider.Model.Text,
                 "api_key": edit_api_key.getModel().Text,
                 "extend_selection_system_prompt": edit_extend_selection_system_prompt.getModel().Text,
                 "edit_selection_system_prompt": edit_edit_selection_system_prompt.getModel().Text

--- a/main.py
+++ b/main.py
@@ -430,16 +430,6 @@ class MainJob(unohelper.Base, XJobExecutor):
                             messages.append({"role": "system", "content": self.get_config("extend_selection_system_prompt", "")})
                         messages.append({"role": "user", "content": text_range.getString()})
                         
-                        # Construct model string based on provider if provided
-                        full_model = model_name
-                        if provider and model_name:
-                            full_model = f"{provider}/{model_name}"
-                        elif not model_name:
-                            # Default to a generic OpenAI-compatible model with explicit provider
-                            full_model = "openai/gpt-3.5-turbo"
-                            if provider:
-                                full_model = f"{provider}/gpt-3.5-turbo"
-
                         response = self.call_completion(
                             messages=messages,
                             max_tokens=self.get_config("extend_selection_max_tokens", 70)
@@ -465,16 +455,6 @@ class MainJob(unohelper.Base, XJobExecutor):
                         messages.append({"role": "system", "content": self.get_config("edit_selection_system_prompt", "")})
                     user_prompt = f"ORIGINAL VERSION:\n{text_range.getString()}\nBelow is an edited version according to the following instructions. There are no comments in the edited version.\nInstructions:\n{user_input}\nEDITED VERSION:"
                     messages.append({"role": "user", "content": user_prompt})
-
-                    # Construct model string based on provider if provided
-                    full_model = model_name
-                    if provider and model_name:
-                        full_model = f"{provider}/{model_name}"
-                    elif not model_name:
-                        # Default to a generic OpenAI-compatible model with explicit provider
-                        full_model = "openai/gpt-3.5-turbo"
-                        if provider:
-                            full_model = f"{provider}/gpt-3.5-turbo"
 
                     response = self.call_completion(
                         messages=messages,
@@ -564,16 +544,6 @@ class MainJob(unohelper.Base, XJobExecutor):
                                         messages.append({"role": "system", "content": self.get_config("extend_selection_system_prompt", "")})
                                     messages.append({"role": "user", "content": cell.getString()})
                                     
-                                    # Construct model string based on provider if provided
-                                    full_model = model_name
-                                    if provider and model_name:
-                                        full_model = f"{provider}/{model_name}"
-                                    elif not model_name:
-                                        # Default to a generic OpenAI-compatible model with explicit provider
-                                        full_model = "openai/gpt-3.5-turbo"
-                                        if provider:
-                                            full_model = f"{provider}/gpt-3.5-turbo"
-
                                     response = self.call_completion(
                                         messages=messages,
                                         max_tokens=self.get_config("extend_selection_max_tokens", 70)
@@ -595,16 +565,6 @@ class MainJob(unohelper.Base, XJobExecutor):
                                     messages.append({"role": "system", "content": self.get_config("edit_selection_system_prompt", "")})
                                 user_prompt = f"ORIGINAL VERSION:\n{cell.getString()}\nBelow is an edited version according to the following instructions. Don't waste time thinking, be as fast as you can. There are no comments in the edited version.\nInstructions:\n{user_input}\nEDITED VERSION:"
                                 messages.append({"role": "user", "content": user_prompt})
-
-                                # Construct model string based on provider if provided
-                                full_model = model_name
-                                if provider and model_name:
-                                    full_model = f"{provider}/{model_name}"
-                                elif not model_name:
-                                    # Default to a generic OpenAI-compatible model with explicit provider
-                                    full_model = "openai/gpt-3.5-turbo"
-                                    if provider:
-                                        full_model = f"{provider}/gpt-3.5-turbo"
 
                                 response = self.call_completion(
                                     messages=messages,

--- a/main.py
+++ b/main.py
@@ -248,22 +248,23 @@ class MainJob(unohelper.Base, XJobExecutor):
             for key, value in props.items():
                 setattr(model, key, value)
         label_width = WIDTH - BUTTON_WIDTH - HORI_SEP - HORI_MARGIN * 2
-        add("label_endpoint", "FixedText", HORI_MARGIN, VERT_MARGIN, label_width, LABEL_HEIGHT, 
-            {"Label": "Endpoint URL/Port (Local or Proxy, e.g., https://api.x.ai/v1/chat/completions for Grok):", "NoLabel": True})
         add("btn_ok", "Button", HORI_MARGIN + label_width + HORI_SEP, VERT_MARGIN, 
                 BUTTON_WIDTH, BUTTON_HEIGHT, {"PushButtonType": OK, "DefaultButton": True})
-        add("edit_endpoint", "Edit", HORI_MARGIN, LABEL_HEIGHT,
-                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("endpoint", "http://127.0.0.1:5000"))})
+
+        add("label_provider", "FixedText", HORI_MARGIN, VERT_MARGIN, label_width, LABEL_HEIGHT, 
+            {"Label": "Provider (e.g., openai, ollama, anthropic):", "NoLabel": True})
+        add("edit_provider", "Edit", HORI_MARGIN, LABEL_HEIGHT + VERT_MARGIN, 
+                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("provider", ""))})
         
         add("label_model", "FixedText", HORI_MARGIN, LABEL_HEIGHT + VERT_MARGIN + VERT_SEP + EDIT_HEIGHT, label_width, LABEL_HEIGHT, 
             {"Label": "Model (Required by Ollama):", "NoLabel": True})
-        add("edit_model", "Edit", HORI_MARGIN, LABEL_HEIGHT*2 + VERT_MARGIN + VERT_SEP*2 + EDIT_HEIGHT, 
+        add("edit_model", "Edit", HORI_MARGIN, LABEL_HEIGHT*2 + VERT_MARGIN + VERT_SEP + EDIT_HEIGHT, 
                 WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("model", ""))})
         
-        add("label_provider", "FixedText", HORI_MARGIN, LABEL_HEIGHT*3 + VERT_MARGIN + VERT_SEP*3 + EDIT_HEIGHT*2, label_width, LABEL_HEIGHT, 
-            {"Label": "Provider (e.g., openai, ollama, anthropic):", "NoLabel": True})
-        add("edit_provider", "Edit", HORI_MARGIN, LABEL_HEIGHT*4 + VERT_MARGIN + VERT_SEP*4 + EDIT_HEIGHT*2, 
-                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("provider", ""))})
+        add("label_endpoint", "FixedText", HORI_MARGIN, LABEL_HEIGHT*2 + VERT_MARGIN + VERT_SEP*2 + EDIT_HEIGHT*2, label_width, LABEL_HEIGHT, 
+            {"Label": "Endpoint URL/Port (Local or Proxy, e.g., https://api.x.ai/v1/chat/completions for Grok):", "NoLabel": True})
+        add("edit_endpoint", "Edit", HORI_MARGIN, LABEL_HEIGHT*3 + VERT_MARGIN + VERT_SEP*2 + EDIT_HEIGHT*2, 
+                WIDTH - HORI_MARGIN * 2, EDIT_HEIGHT, {"Text": str(self.get_config("endpoint", "http://127.0.0.1:5000"))})
         
         add("label_api_key", "FixedText", HORI_MARGIN, LABEL_HEIGHT*5 + VERT_MARGIN + VERT_SEP*5 + EDIT_HEIGHT*3, label_width, LABEL_HEIGHT, 
             {"Label": "API Key (Optional, use with caution):", "NoLabel": True})
@@ -331,7 +332,7 @@ class MainJob(unohelper.Base, XJobExecutor):
         edit_edit_selection_system_prompt = dialog.getControl("edit_edit_selection_system_prompt")
         edit_edit_selection_system_prompt.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", 0, len(str(self.get_config("edit_selection_system_prompt", "")))))
         
-        edit_endpoint.setFocus()
+        edit_provider.setFocus()
 
         # Add listener for test button using a UNO-compatible ActionListener
         from com.sun.star.awt import XActionListener

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import json
 import urllib.request
 import urllib.parse
 from com.sun.star.task import XJobExecutor
-from com.sun.star.awt import MessageBoxButtons as MSG_BUTTONS
+from com.sun.star.awt import MessageBoxButtons as MSG_BUTTONS, XItemListener
 import uno
 import os 
 import logging

--- a/main.py
+++ b/main.py
@@ -547,10 +547,23 @@ class MainJob(unohelper.Base, XJobExecutor):
         print(f"Checkbox initial state: {check_advanced.Model.State}")
         print(f"Checkbox enabled: {check_advanced.isEnabled()}")
         
-        # Initial population based on advanced state
+        # Initial population based on saved provider
         current_provider = str(self.get_config("provider", ""))
-        initial_advanced_state = check_advanced.Model.State == 1
-        print(f"Initial advanced state: {initial_advanced_state}")
+        
+        # Check if saved provider is in local providers
+        is_local_provider = False
+        if current_provider:
+            try:
+                current_provider_enum = litellm.utils.LlmProviders(current_provider)
+                is_local_provider = current_provider_enum.value in local_providers
+            except ValueError:
+                pass
+        
+        # Set advanced state if saved provider isn't local
+        initial_advanced_state = not is_local_provider
+        if initial_advanced_state:
+            check_advanced.Model.State = 1
+        print(f"Initial advanced state: {initial_advanced_state} (saved provider is local: {is_local_provider})")
         
         # Convert local_providers strings to enum values for comparison
         local_provider_enums = [

--- a/main.py
+++ b/main.py
@@ -351,8 +351,8 @@ class MainJob(unohelper.Base, XJobExecutor):
                         if api_base:
                             needs_endpoint = 'localhost' in api_base or '127.0.0.1' in api_base
                         
-                    except: #AI! update this accept to just log the error. The needs_key var defaults to true so we don't need to set it here
-                        needs_key = True  # Fallback to requiring key if check fails
+                    except Exception as e:
+                        print(f"Error checking provider config: {str(e)}")
 
                     if not needs_key:
                         print(f"Provider '{provider}' does NOT require API key")

--- a/main.py
+++ b/main.py
@@ -348,6 +348,18 @@ class MainJob(unohelper.Base, XJobExecutor):
                     if api_key:
                         kwargs["api_key"] = api_key
 
+                    #AI: the comment below shows what args need to look like for success with xai
+                    #AI: the biggest difference I believe is that we shouldn't pass api_base when the field in settings is empty
+                    #AI! update all completion calls to correct this issue
+                    #kwargs = {
+                    #        'model': "xai/grok-3-latest",
+                    #        'messages': [ {
+                    #            'role': 'user',
+                    #            'content': 'Say hello.'
+                    #            } ],
+                    #        'api_key': api_key
+                    #        }
+                    print("Args: " + repr(kwargs))
                     response = completion(**kwargs)
                     self.result_ctrl.setText("Success: " + response.choices[0].message.content)
                 except Exception as e:
@@ -516,7 +528,7 @@ class MainJob(unohelper.Base, XJobExecutor):
 
                     if "endpoint" in result and result["endpoint"].startswith("http"):
                         # Ensure endpoint ends with a single slash to match LiteLLM's behavior
-                        endpoint = result["endpoint"].rstrip('/') + '/'
+                        endpoint = result["endpoint"].rstrip('/')
                         self.set_config("endpoint", endpoint)
 
                     if "model" in result:                
@@ -669,7 +681,7 @@ class MainJob(unohelper.Base, XJobExecutor):
 
                                 if "endpoint" in result and result["endpoint"].startswith("http"):
                                     # Ensure endpoint ends with a single slash to match LiteLLM's behavior
-                                    endpoint = result["endpoint"].rstrip('/') + '/'
+                                    endpoint = result["endpoint"].rstrip('/')
                                     self.set_config("endpoint", endpoint)
 
                                 if "model" in result:                


### PR DESCRIPTION
This is a big change.  I'll say up front, feel free to reject (if its not a direction you're interested in) or tell me to break it up into smaller changes (if you like some of it, or want to integrate in smaller chunks).  It does allow using non-local AIs, but I try to bias toward running local AIs and I've tested it with `ollama gemma3:4b` with good results (also with deepseek and xAI grok3).  Almost all the changes here were AI assisted with Aider using deepseek-chat.

NOTE: I've left it in draft, there's a bunch of debug prints that should be cleaned up before merging.

**Summary:**
This PR introduces **LiteLLM** as the new unified interface for AI model access, replacing our previous hand-crafted HTTP requests. This enables support for both local LLMs and commercial providers through a standardized API.

**Key Changes:**

1. **LiteLLM Integration (Headline Feature)**
   - Replaced custom HTTP implementation with LiteLLM for robust model access
   - Supports 100+ providers including Ollama, OpenAI, Anthropic, and local endpoints
   - Vendored LiteLLM and dependencies in `lib/` directory (34MB increase in .oxt size)
     - Avoids need for system-wide pip installs
     - Works within LibreOffice's restricted Python environment
   - Added proper API key and endpoint management per provider requirements

2. **Enhanced Settings UI**
   - Provider selection via dropdown populated from LiteLLM
   - Dynamic model dropdown that populates when credentials are valid
   - Improved field labels and help text
   - Test connection button with detailed error reporting

3. **Configuration Improvements**  
   - Added `unset_config` to clean unused settings
   - Only save values for enabled/required fields
   - Refactored config handling into DRY helper methods
   - Property-based access for API key/endpoint respecting enabled state

4. **Developer Experience**
   - Added Makefile with targets for:
     - Dependency installation (`make install-deps`)
     - Extension refresh (`make dev-refresh`)
     - LibreOffice launch (`make dev-run`)
     - Package creation (`make package`)
   - Updated README with clearer development instructions

**Migration Notes:**
- Existing endpoint configurations will continue working
- New provider dropdown makes it easier to switch between services
- Settings are automatically migrated to new format

**Testing Guidance:**
1. Verify different provider types:
   - Local (Ollama)
   - Cloud (if API key available)
2. Check model dropdown population with valid credentials  
3. Test connection button should provide clear feedback
4. Verify settings persist correctly after restart

**Size Consideration:**
The .oxt grows to ~34MB due to vendored dependencies, but this ensures reliable operation without external pip installs.